### PR TITLE
Fix the Python version to test

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -5,6 +5,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python: ["3.7", "3.8", "3.9", "3.10"]
     steps:

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.7", "3.8", "3.9", "3.10"]
+        python: ["3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.8", "3.9", "3.10"]
+        python: ["3.8", "3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -16,9 +16,12 @@ jobs:
           python-version: "${{ matrix.python }}"
           cache: "pipenv"
 
-      - run: pipx install pipenv
-
-      - run: pipenv sync --dev
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pipenv
+          pipenv --python "${{ matrix.python }}"
+          pipenv install --system --dev
 
       - name: Lint
         run: pipenv run lint
@@ -33,7 +36,7 @@ jobs:
           fi
 
       - name: Test
-        run: pipenv run test
+        run: python -m pytest --cov=example example --doctest-modules --cov-report=xml
 
       - name: Upload coverage report to Codecov
         if: matrix.python == '3.10'

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -22,6 +22,15 @@ jobs:
       - name: Lint
         run: pipenv run lint
 
+      - name: Check Python version
+        run: |
+          actual_version=$(pipenv run python --version)
+          expected_version="Python ${{ matrix.python }}"
+          if [ "$actual_version" == *"$expected_version"* ]; then
+            echo "Expected $expected_version, but got $actual_version"
+            exit 1
+          fi
+
       - name: Test
         run: pipenv run test
 

--- a/Pipfile
+++ b/Pipfile
@@ -23,9 +23,6 @@ pytest-cov = "*"
 flake8 = "*"
 mypy = "*"
 
-[requires]
-python_version = "3.10"
-
 [scripts]
 test = "make test"
 lint = "make lint"


### PR DESCRIPTION
Desired state: Each version of Python is tested in the matrix build
Current state: In fact, all are tested in Python 3.10 in GitHub Actions

What this PR does: Test each version of Python in the matrix build

- [x] Check Python version in matrix build
- [x] Use fail-fast: false to make each version tested independently to the end.
- [x]  Use pipenv only for system installation to test with the version installed on the system