### PR TITLE
Testing multiple Python versions and speeding up CI

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -1,6 +1,6 @@
 name: Lint and Test Python
-
 on: [push]
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -9,19 +9,37 @@ jobs:
       matrix:
         python: ["3.8", "3.9", "3.10", "3.11"]
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v4
+      - name: Set up Python
+        id: setup-python
+        uses: actions/setup-python@v4
         with:
           python-version: "${{ matrix.python }}"
-          cache: "pipenv"
+          cache: pipenv
 
-      - name: Install dependencies
+      - name: Install pipenv
         run: |
-          python -m pip install --upgrade pip
           python -m pip install pipenv
           pipenv --python "${{ matrix.python }}"
-          pipenv install --system --dev
+
+      - name: Cache
+        id: cache-python
+        uses: actions/cache@v3
+        with:
+          path: ~/.local/share/virtualenvs
+          key: ${{ runner.os }}-build-${{ matrix.python }}-${{ hashFiles('**/Pipfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ matrix.python }}-${{ hashFiles('**/Pipfile.lock') }}
+            ${{ runner.os }}-build-${{ matrix.python }}-
+            ${{ runner.os }}-
+
+      - if: ${{ steps.cache-python.outputs.cache-hit != 'true' }}
+        name: Install dependencies
+        run: |
+          pipenv sync --dev
+          pipenv clean
 
       - name: Lint
         run: pipenv run lint
@@ -36,7 +54,7 @@ jobs:
           fi
 
       - name: Test
-        run: python -m pytest --cov=example example --doctest-modules --cov-report=xml
+        run: pipenv run pytest --cov=example example --doctest-modules --cov-report=xml
 
       - name: Upload coverage report to Codecov
         if: matrix.python == '3.10'


### PR DESCRIPTION
The test for multiple Python versions was fixed correctly (#5), but CI speed has slowed down.

 # Cause 1. Cache is not effective

When installing packages with pipenv using `pipenv install --system --dev`, it is installed on the system. Therefore, the default cache destination and path do not match, and a full installation is performed.

 # Cause 2. ?

If there is anything, I will resolve it
