### PR TITLE
Add tests for matplotlib

### DIFF
--- a/data/examples/graphs/test1.svg
+++ b/data/examples/graphs/test1.svg
@@ -1,0 +1,874 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="460.8pt" height="345.6pt" viewBox="0 0 460.8 345.6" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.6.3, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 345.6 
+L 460.8 345.6 
+L 460.8 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 57.6 307.584 
+L 414.72 307.584 
+L 414.72 41.472 
+L 57.6 41.472 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="m067c08e0d7" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m067c08e0d7" x="73.832727" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 0.0 -->
+      <g transform="translate(65.881165 322.182437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-2e" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#m067c08e0d7" x="114.414545" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 2.5 -->
+      <g transform="translate(106.462983 322.182437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#m067c08e0d7" x="154.996364" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 5.0 -->
+      <g transform="translate(147.044801 322.182437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-35"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m067c08e0d7" x="195.578182" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 7.5 -->
+      <g transform="translate(187.626619 322.182437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-37"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#m067c08e0d7" x="236.16" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 10.0 -->
+      <g transform="translate(225.027188 322.182437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m067c08e0d7" x="276.741818" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 12.5 -->
+      <g transform="translate(265.609006 322.182437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#m067c08e0d7" x="317.323636" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 15.0 -->
+      <g transform="translate(306.190824 322.182437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m067c08e0d7" x="357.905455" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 17.5 -->
+      <g transform="translate(346.772642 322.182437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#m067c08e0d7" x="398.487273" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 20.0 -->
+      <g transform="translate(387.35446 322.182437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_10">
+     <!-- x -->
+     <g transform="translate(233.200625 335.860562) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-78"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_10">
+      <defs>
+       <path id="m054f990ef5" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m054f990ef5" x="57.6" y="295.751039" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- −1.00 -->
+      <g transform="translate(19.954687 299.550258) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-2212" d="M 678 2272 
+L 4684 2272 
+L 4684 1741 
+L 678 1741 
+L 678 2272 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-31" x="83.789062"/>
+       <use xlink:href="#DejaVuSans-2e" x="147.412109"/>
+       <use xlink:href="#DejaVuSans-30" x="179.199219"/>
+       <use xlink:href="#DejaVuSans-30" x="242.822266"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_11">
+      <g>
+       <use xlink:href="#m054f990ef5" x="57.6" y="265.478022" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- −0.75 -->
+      <g transform="translate(19.954687 269.277241) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-30" x="83.789062"/>
+       <use xlink:href="#DejaVuSans-2e" x="147.412109"/>
+       <use xlink:href="#DejaVuSans-37" x="179.199219"/>
+       <use xlink:href="#DejaVuSans-35" x="242.822266"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m054f990ef5" x="57.6" y="235.205006" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- −0.50 -->
+      <g transform="translate(19.954687 239.004225) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-30" x="83.789062"/>
+       <use xlink:href="#DejaVuSans-2e" x="147.412109"/>
+       <use xlink:href="#DejaVuSans-35" x="179.199219"/>
+       <use xlink:href="#DejaVuSans-30" x="242.822266"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#m054f990ef5" x="57.6" y="204.93199" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- −0.25 -->
+      <g transform="translate(19.954687 208.731208) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-30" x="83.789062"/>
+       <use xlink:href="#DejaVuSans-2e" x="147.412109"/>
+       <use xlink:href="#DejaVuSans-32" x="179.199219"/>
+       <use xlink:href="#DejaVuSans-35" x="242.822266"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m054f990ef5" x="57.6" y="174.658973" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 0.00 -->
+      <g transform="translate(28.334375 178.458192) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_15">
+      <g>
+       <use xlink:href="#m054f990ef5" x="57.6" y="144.385957" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- 0.25 -->
+      <g transform="translate(28.334375 148.185176) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m054f990ef5" x="57.6" y="114.112941" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- 0.50 -->
+      <g transform="translate(28.334375 117.912159) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_17">
+      <g>
+       <use xlink:href="#m054f990ef5" x="57.6" y="83.839924" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_18">
+      <!-- 0.75 -->
+      <g transform="translate(28.334375 87.639143) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-37" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#m054f990ef5" x="57.6" y="53.566908" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_19">
+      <!-- 1.00 -->
+      <g transform="translate(28.334375 57.366127) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_20">
+     <!-- sin(x) -->
+     <g transform="translate(13.875 188.551437) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-73"/>
+      <use xlink:href="#DejaVuSans-69" x="52.099609"/>
+      <use xlink:href="#DejaVuSans-6e" x="79.882812"/>
+      <use xlink:href="#DejaVuSans-28" x="143.261719"/>
+      <use xlink:href="#DejaVuSans-78" x="182.275391"/>
+      <use xlink:href="#DejaVuSans-29" x="241.455078"/>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_19">
+    <path d="M 73.832727 174.658973 
+L 77.112066 150.361989 
+L 80.391405 127.053249 
+L 83.670744 105.680803 
+L 86.950083 87.113943 
+L 90.229421 72.107851 
+L 93.50876 61.272877 
+L 96.788099 55.049717 
+L 100.067438 53.691491 
+L 103.346777 57.253441 
+L 106.626116 65.59069 
+L 109.905455 78.364134 
+L 113.184793 95.054231 
+L 116.464132 114.982134 
+L 119.743471 137.337307 
+L 123.02281 161.210484 
+L 126.302149 185.630659 
+L 129.581488 209.604576 
+L 132.860826 232.157132 
+L 136.140165 252.371034 
+L 139.419504 269.42411 
+L 142.698843 282.622753 
+L 145.978182 291.430125 
+L 149.257521 295.488 
+L 152.53686 294.63133 
+L 155.816198 288.894958 
+L 159.095537 278.512204 
+L 162.374876 263.905371 
+L 165.654215 245.668569 
+L 168.933554 224.543556 
+L 172.212893 201.389559 
+L 175.492231 177.148335 
+L 178.77157 152.80586 
+L 182.050909 129.352228 
+L 185.330248 107.741382 
+L 188.609587 88.852313 
+L 191.888926 73.453304 
+L 195.168264 62.170689 
+L 198.447603 55.463372 
+L 201.726942 53.604163 
+L 205.006281 56.668682 
+L 208.28562 64.532286 
+L 211.564959 76.875132 
+L 214.844298 93.195194 
+L 218.123636 112.828677 
+L 221.402975 134.977018 
+L 224.682314 158.739364 
+L 227.961653 183.149218 
+L 231.240992 207.213743 
+L 234.520331 229.95415 
+L 237.799669 250.445506 
+L 241.079008 267.854355 
+L 244.358347 281.472617 
+L 247.637686 290.746389 
+L 250.917025 295.298475 
+L 254.196364 294.943723 
+L 257.475702 289.696564 
+L 260.755041 279.770418 
+L 264.03438 265.569017 
+L 267.313719 247.669982 
+L 270.593058 226.80133 
+L 273.872397 203.811863 
+L 277.151736 179.636645 
+L 280.431074 155.258967 
+L 283.710413 131.670356 
+L 286.989752 109.830245 
+L 290.269091 90.626949 
+L 293.54843 74.841533 
+L 296.827769 63.116046 
+L 300.107107 55.927406 
+L 303.386446 53.568 
+L 306.665785 56.133794 
+L 309.945124 63.520427 
+L 313.224463 75.427459 
+L 316.503802 91.370589 
+L 319.78314 110.701353 
+L 323.062479 132.6335 
+L 326.341818 156.274973 
+L 329.621157 180.664188 
+L 332.900496 204.80915 
+L 336.179835 227.727797 
+L 339.459174 248.487946 
+L 342.738512 266.24521 
+L 346.017851 280.277336 
+L 349.29719 290.013589 
+L 352.576529 295.05796 
+L 355.855868 295.205277 
+L 359.135207 290.449548 
+L 362.414545 280.984206 
+L 365.693884 267.19424 
+L 368.973223 249.640535 
+L 372.252562 229.037065 
+L 375.531901 206.221845 
+L 378.81124 182.122851 
+L 382.090579 157.720274 
+L 385.369917 134.006654 
+L 388.649256 111.946509 
+L 391.928595 92.437102 
+L 395.207934 76.27195 
+L 398.487273 64.108547 
+" clip-path="url(#pb8778e6b03)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5; stroke-linecap: square"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 57.6 307.584 
+L 57.6 41.472 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 414.72 307.584 
+L 414.72 41.472 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 57.6 307.584 
+L 414.72 307.584 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 57.6 41.472 
+L 414.72 41.472 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_21">
+    <!-- This is a plot -->
+    <g transform="translate(198.210938 35.472) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-54" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-54"/>
+     <use xlink:href="#DejaVuSans-68" x="61.083984"/>
+     <use xlink:href="#DejaVuSans-69" x="124.462891"/>
+     <use xlink:href="#DejaVuSans-73" x="152.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="204.345703"/>
+     <use xlink:href="#DejaVuSans-69" x="236.132812"/>
+     <use xlink:href="#DejaVuSans-73" x="263.916016"/>
+     <use xlink:href="#DejaVuSans-20" x="316.015625"/>
+     <use xlink:href="#DejaVuSans-61" x="347.802734"/>
+     <use xlink:href="#DejaVuSans-20" x="409.082031"/>
+     <use xlink:href="#DejaVuSans-70" x="440.869141"/>
+     <use xlink:href="#DejaVuSans-6c" x="504.345703"/>
+     <use xlink:href="#DejaVuSans-6f" x="532.128906"/>
+     <use xlink:href="#DejaVuSans-74" x="593.310547"/>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pb8778e6b03">
+   <rect x="57.6" y="41.472" width="357.12" height="266.112"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/data/examples/graphs/test2.svg
+++ b/data/examples/graphs/test2.svg
@@ -1,0 +1,1018 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="460.8pt" height="345.6pt" viewBox="0 0 460.8 345.6" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.6.3, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 345.6 
+L 460.8 345.6 
+L 460.8 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 57.6 307.584 
+L 414.72 307.584 
+L 414.72 41.472 
+L 57.6 41.472 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 73.832727 307.584 
+L 90.065455 307.584 
+L 90.065455 301.402537 
+L 73.832727 301.402537 
+z
+" clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 90.065455 307.584 
+L 106.298182 307.584 
+L 106.298182 295.221073 
+L 90.065455 295.221073 
+z
+" clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 106.298182 307.584 
+L 122.530909 307.584 
+L 122.530909 289.03961 
+L 106.298182 289.03961 
+z
+" clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 122.530909 307.584 
+L 138.763636 307.584 
+L 138.763636 284.918634 
+L 122.530909 284.918634 
+z
+" clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 138.763636 307.584 
+L 154.996364 307.584 
+L 154.996364 245.769366 
+L 138.763636 245.769366 
+z
+" clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 154.996364 307.584 
+L 171.229091 307.584 
+L 171.229091 225.164488 
+L 154.996364 225.164488 
+z
+" clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 171.229091 307.584 
+L 187.461818 307.584 
+L 187.461818 186.01522 
+L 171.229091 186.01522 
+z
+" clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 187.461818 307.584 
+L 203.694545 307.584 
+L 203.694545 128.321561 
+L 187.461818 128.321561 
+z
+" clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 203.694545 307.584 
+L 219.927273 307.584 
+L 219.927273 95.353756 
+L 203.694545 95.353756 
+z
+" clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 219.927273 307.584 
+L 236.16 307.584 
+L 236.16 72.68839 
+L 219.927273 72.68839 
+z
+" clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 236.16 307.584 
+L 252.392727 307.584 
+L 252.392727 68.567415 
+L 236.16 68.567415 
+z
+" clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 252.392727 307.584 
+L 268.625455 307.584 
+L 268.625455 54.144 
+L 252.392727 54.144 
+z
+" clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 268.625455 307.584 
+L 284.858182 307.584 
+L 284.858182 136.563512 
+L 268.625455 136.563512 
+z
+" clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 284.858182 307.584 
+L 301.090909 307.584 
+L 301.090909 148.926439 
+L 284.858182 148.926439 
+z
+" clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 301.090909 307.584 
+L 317.323636 307.584 
+L 317.323636 208.680585 
+L 301.090909 208.680585 
+z
+" clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 317.323636 307.584 
+L 333.556364 307.584 
+L 333.556364 229.285463 
+L 317.323636 229.285463 
+z
+" clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 333.556364 307.584 
+L 349.789091 307.584 
+L 349.789091 262.253268 
+L 333.556364 262.253268 
+z
+" clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 349.789091 307.584 
+L 366.021818 307.584 
+L 366.021818 274.616195 
+L 349.789091 274.616195 
+z
+" clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 366.021818 307.584 
+L 382.254545 307.584 
+L 382.254545 284.918634 
+L 366.021818 284.918634 
+z
+" clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 382.254545 307.584 
+L 398.487273 307.584 
+L 398.487273 299.342049 
+L 382.254545 299.342049 
+z
+" clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="m067c08e0d7" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m067c08e0d7" x="76.413135" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- −3 -->
+      <g transform="translate(69.042041 322.182437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-2212" d="M 678 2272 
+L 4684 2272 
+L 4684 1741 
+L 678 1741 
+L 678 2272 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-33" x="83.789062"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#m067c08e0d7" x="132.335045" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- −2 -->
+      <g transform="translate(124.963951 322.182437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-32" x="83.789062"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#m067c08e0d7" x="188.256955" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- −1 -->
+      <g transform="translate(180.885861 322.182437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-31" x="83.789062"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m067c08e0d7" x="244.178865" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 0 -->
+      <g transform="translate(240.997615 322.182437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#m067c08e0d7" x="300.100775" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 1 -->
+      <g transform="translate(296.919525 322.182437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m067c08e0d7" x="356.022684" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 2 -->
+      <g transform="translate(352.841434 322.182437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#m067c08e0d7" x="411.944594" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 3 -->
+      <g transform="translate(408.763344 322.182437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-33"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_8">
+     <!-- x -->
+     <g transform="translate(233.200625 335.860562) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-78"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_8">
+      <defs>
+       <path id="m054f990ef5" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m054f990ef5" x="57.6" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 0 -->
+      <g transform="translate(44.2375 311.383219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#m054f990ef5" x="57.6" y="266.374244" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 20 -->
+      <g transform="translate(37.875 270.173463) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m054f990ef5" x="57.6" y="225.164488" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 40 -->
+      <g transform="translate(37.875 228.963707) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_11">
+      <g>
+       <use xlink:href="#m054f990ef5" x="57.6" y="183.954732" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 60 -->
+      <g transform="translate(37.875 187.75395) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-36"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m054f990ef5" x="57.6" y="142.744976" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 80 -->
+      <g transform="translate(37.875 146.544194) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-38"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#m054f990ef5" x="57.6" y="101.53522" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- 100 -->
+      <g transform="translate(31.5125 105.334438) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m054f990ef5" x="57.6" y="60.325463" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 120 -->
+      <g transform="translate(31.5125 64.124682) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_16">
+     <!-- y (random) -->
+     <g transform="translate(25.432812 202.370187) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-79" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-79"/>
+      <use xlink:href="#DejaVuSans-20" x="59.179688"/>
+      <use xlink:href="#DejaVuSans-28" x="90.966797"/>
+      <use xlink:href="#DejaVuSans-72" x="129.980469"/>
+      <use xlink:href="#DejaVuSans-61" x="171.09375"/>
+      <use xlink:href="#DejaVuSans-6e" x="232.373047"/>
+      <use xlink:href="#DejaVuSans-64" x="295.751953"/>
+      <use xlink:href="#DejaVuSans-6f" x="359.228516"/>
+      <use xlink:href="#DejaVuSans-6d" x="420.410156"/>
+      <use xlink:href="#DejaVuSans-29" x="517.822266"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_23">
+    <path d="M 57.6 307.584 
+L 57.6 41.472 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_24">
+    <path d="M 414.72 307.584 
+L 414.72 41.472 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_25">
+    <path d="M 57.6 307.584 
+L 414.72 307.584 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_26">
+    <path d="M 57.6 41.472 
+L 414.72 41.472 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_17">
+    <!-- This is a histogram -->
+    <g transform="translate(179.295 35.472) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-54" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-67" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-54"/>
+     <use xlink:href="#DejaVuSans-68" x="61.083984"/>
+     <use xlink:href="#DejaVuSans-69" x="124.462891"/>
+     <use xlink:href="#DejaVuSans-73" x="152.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="204.345703"/>
+     <use xlink:href="#DejaVuSans-69" x="236.132812"/>
+     <use xlink:href="#DejaVuSans-73" x="263.916016"/>
+     <use xlink:href="#DejaVuSans-20" x="316.015625"/>
+     <use xlink:href="#DejaVuSans-61" x="347.802734"/>
+     <use xlink:href="#DejaVuSans-20" x="409.082031"/>
+     <use xlink:href="#DejaVuSans-68" x="440.869141"/>
+     <use xlink:href="#DejaVuSans-69" x="504.248047"/>
+     <use xlink:href="#DejaVuSans-73" x="532.03125"/>
+     <use xlink:href="#DejaVuSans-74" x="584.130859"/>
+     <use xlink:href="#DejaVuSans-6f" x="623.339844"/>
+     <use xlink:href="#DejaVuSans-67" x="684.521484"/>
+     <use xlink:href="#DejaVuSans-72" x="747.998047"/>
+     <use xlink:href="#DejaVuSans-61" x="789.111328"/>
+     <use xlink:href="#DejaVuSans-6d" x="850.390625"/>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pb8778e6b03">
+   <rect x="57.6" y="41.472" width="357.12" height="266.112"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/data/examples/graphs/test3.svg
+++ b/data/examples/graphs/test3.svg
@@ -1,0 +1,695 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="460.8pt" height="345.6pt" viewBox="0 0 460.8 345.6" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.6.3, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 345.6 
+L 460.8 345.6 
+L 460.8 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 57.6 307.584 
+L 414.72 307.584 
+L 414.72 41.472 
+L 57.6 41.472 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 73.832727 307.584 
+L 127.941818 307.584 
+L 127.941818 307.584 
+L 73.832727 307.584 
+z
+" clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 141.469091 307.584 
+L 195.578182 307.584 
+L 195.578182 244.224 
+L 141.469091 244.224 
+z
+" clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 209.105455 307.584 
+L 263.214545 307.584 
+L 263.214545 180.864 
+L 209.105455 180.864 
+z
+" clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 276.741818 307.584 
+L 330.850909 307.584 
+L 330.850909 117.504 
+L 276.741818 117.504 
+z
+" clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 344.378182 307.584 
+L 398.487273 307.584 
+L 398.487273 54.144 
+L 344.378182 54.144 
+z
+" clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="m067c08e0d7" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m067c08e0d7" x="100.887273" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 0 -->
+      <g transform="translate(97.706023 322.182437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#m067c08e0d7" x="168.523636" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 1 -->
+      <g transform="translate(165.342386 322.182437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#m067c08e0d7" x="236.16" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 2 -->
+      <g transform="translate(232.97875 322.182437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m067c08e0d7" x="303.796364" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 3 -->
+      <g transform="translate(300.615114 322.182437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-33"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#m067c08e0d7" x="371.432727" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 4 -->
+      <g transform="translate(368.251477 322.182437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_6">
+     <!-- x -->
+     <g transform="translate(233.200625 335.860562) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-78"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_6">
+      <defs>
+       <path id="m054f990ef5" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m054f990ef5" x="57.6" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 0.0 -->
+      <g transform="translate(34.696875 311.383219) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-2e" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#m054f990ef5" x="57.6" y="275.904" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 0.5 -->
+      <g transform="translate(34.696875 279.703219) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m054f990ef5" x="57.6" y="244.224" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 1.0 -->
+      <g transform="translate(34.696875 248.023219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#m054f990ef5" x="57.6" y="212.544" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 1.5 -->
+      <g transform="translate(34.696875 216.343219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m054f990ef5" x="57.6" y="180.864" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 2.0 -->
+      <g transform="translate(34.696875 184.663219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_11">
+      <g>
+       <use xlink:href="#m054f990ef5" x="57.6" y="149.184" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 2.5 -->
+      <g transform="translate(34.696875 152.983219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m054f990ef5" x="57.6" y="117.504" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 3.0 -->
+      <g transform="translate(34.696875 121.303219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#m054f990ef5" x="57.6" y="85.824" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- 3.5 -->
+      <g transform="translate(34.696875 89.623219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m054f990ef5" x="57.6" y="54.144" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 4.0 -->
+      <g transform="translate(34.696875 57.943219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-34"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_16">
+     <!-- y -->
+     <g transform="translate(28.617188 177.487375) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-79" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-79"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_8">
+    <path d="M 57.6 307.584 
+L 57.6 41.472 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 414.72 307.584 
+L 414.72 41.472 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 57.6 307.584 
+L 414.72 307.584 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 57.6 41.472 
+L 414.72 41.472 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_17">
+    <!-- This is a bar -->
+    <g transform="translate(199.757812 35.472) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-54" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-62" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-54"/>
+     <use xlink:href="#DejaVuSans-68" x="61.083984"/>
+     <use xlink:href="#DejaVuSans-69" x="124.462891"/>
+     <use xlink:href="#DejaVuSans-73" x="152.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="204.345703"/>
+     <use xlink:href="#DejaVuSans-69" x="236.132812"/>
+     <use xlink:href="#DejaVuSans-73" x="263.916016"/>
+     <use xlink:href="#DejaVuSans-20" x="316.015625"/>
+     <use xlink:href="#DejaVuSans-61" x="347.802734"/>
+     <use xlink:href="#DejaVuSans-20" x="409.082031"/>
+     <use xlink:href="#DejaVuSans-62" x="440.869141"/>
+     <use xlink:href="#DejaVuSans-61" x="504.345703"/>
+     <use xlink:href="#DejaVuSans-72" x="565.625"/>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pb8778e6b03">
+   <rect x="57.6" y="41.472" width="357.12" height="266.112"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/data/examples/graphs/test4.svg
+++ b/data/examples/graphs/test4.svg
@@ -1,0 +1,790 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="460.8pt" height="345.6pt" viewBox="0 0 460.8 345.6" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.6.3, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 345.6 
+L 460.8 345.6 
+L 460.8 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 57.6 307.584 
+L 414.72 307.584 
+L 414.72 41.472 
+L 57.6 41.472 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="PathCollection_1">
+    <defs>
+     <path id="me6cd846f7f" d="M 0 3 
+C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
+C 2.683901 1.55874 3 0.795609 3 0 
+C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
+C 1.55874 -2.683901 0.795609 -3 0 -3 
+C -0.795609 -3 -1.55874 -2.683901 -2.12132 -2.12132 
+C -2.683901 -1.55874 -3 -0.795609 -3 0 
+C -3 0.795609 -2.683901 1.55874 -2.12132 2.12132 
+C -1.55874 2.683901 -0.795609 3 0 3 
+z
+" style="stroke: #1f77b4"/>
+    </defs>
+    <g clip-path="url(#pb8778e6b03)">
+     <use xlink:href="#me6cd846f7f" x="73.832727" y="295.488" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me6cd846f7f" x="154.996364" y="235.008" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me6cd846f7f" x="236.16" y="174.528" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me6cd846f7f" x="317.323636" y="114.048" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me6cd846f7f" x="398.487273" y="53.568" style="fill: #1f77b4; stroke: #1f77b4"/>
+    </g>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="m067c08e0d7" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m067c08e0d7" x="73.832727" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 0.0 -->
+      <g transform="translate(65.881165 322.182437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-2e" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#m067c08e0d7" x="114.414545" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 0.5 -->
+      <g transform="translate(106.462983 322.182437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#m067c08e0d7" x="154.996364" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 1.0 -->
+      <g transform="translate(147.044801 322.182437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m067c08e0d7" x="195.578182" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 1.5 -->
+      <g transform="translate(187.626619 322.182437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#m067c08e0d7" x="236.16" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 2.0 -->
+      <g transform="translate(228.208438 322.182437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m067c08e0d7" x="276.741818" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 2.5 -->
+      <g transform="translate(268.790256 322.182437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#m067c08e0d7" x="317.323636" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 3.0 -->
+      <g transform="translate(309.372074 322.182437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m067c08e0d7" x="357.905455" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 3.5 -->
+      <g transform="translate(349.953892 322.182437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#m067c08e0d7" x="398.487273" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 4.0 -->
+      <g transform="translate(390.53571 322.182437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_10">
+     <!-- x -->
+     <g transform="translate(233.200625 335.860562) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-78"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_10">
+      <defs>
+       <path id="m054f990ef5" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m054f990ef5" x="57.6" y="295.488" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 0.0 -->
+      <g transform="translate(34.696875 299.287219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_11">
+      <g>
+       <use xlink:href="#m054f990ef5" x="57.6" y="265.248" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 0.5 -->
+      <g transform="translate(34.696875 269.047219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m054f990ef5" x="57.6" y="235.008" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 1.0 -->
+      <g transform="translate(34.696875 238.807219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#m054f990ef5" x="57.6" y="204.768" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- 1.5 -->
+      <g transform="translate(34.696875 208.567219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m054f990ef5" x="57.6" y="174.528" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 2.0 -->
+      <g transform="translate(34.696875 178.327219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_15">
+      <g>
+       <use xlink:href="#m054f990ef5" x="57.6" y="144.288" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- 2.5 -->
+      <g transform="translate(34.696875 148.087219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m054f990ef5" x="57.6" y="114.048" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- 3.0 -->
+      <g transform="translate(34.696875 117.847219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_17">
+      <g>
+       <use xlink:href="#m054f990ef5" x="57.6" y="83.808" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_18">
+      <!-- 3.5 -->
+      <g transform="translate(34.696875 87.607219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#m054f990ef5" x="57.6" y="53.568" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_19">
+      <!-- 4.0 -->
+      <g transform="translate(34.696875 57.367219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-34"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_20">
+     <!-- y -->
+     <g transform="translate(28.617188 177.487375) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-79" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-79"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 57.6 307.584 
+L 57.6 41.472 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 414.72 307.584 
+L 414.72 41.472 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 57.6 307.584 
+L 414.72 307.584 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 57.6 41.472 
+L 414.72 41.472 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_21">
+    <!-- This is a scatter -->
+    <g transform="translate(188.745937 35.472) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-54" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-54"/>
+     <use xlink:href="#DejaVuSans-68" x="61.083984"/>
+     <use xlink:href="#DejaVuSans-69" x="124.462891"/>
+     <use xlink:href="#DejaVuSans-73" x="152.246094"/>
+     <use xlink:href="#DejaVuSans-20" x="204.345703"/>
+     <use xlink:href="#DejaVuSans-69" x="236.132812"/>
+     <use xlink:href="#DejaVuSans-73" x="263.916016"/>
+     <use xlink:href="#DejaVuSans-20" x="316.015625"/>
+     <use xlink:href="#DejaVuSans-61" x="347.802734"/>
+     <use xlink:href="#DejaVuSans-20" x="409.082031"/>
+     <use xlink:href="#DejaVuSans-73" x="440.869141"/>
+     <use xlink:href="#DejaVuSans-63" x="492.96875"/>
+     <use xlink:href="#DejaVuSans-61" x="547.949219"/>
+     <use xlink:href="#DejaVuSans-74" x="609.228516"/>
+     <use xlink:href="#DejaVuSans-74" x="648.4375"/>
+     <use xlink:href="#DejaVuSans-65" x="687.646484"/>
+     <use xlink:href="#DejaVuSans-72" x="749.169922"/>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pb8778e6b03">
+   <rect x="57.6" y="41.472" width="357.12" height="266.112"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/data/matplotlib-example.svg
+++ b/data/matplotlib-example.svg
@@ -1,0 +1,590 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="460.8pt" height="345.6pt" viewBox="0 0 460.8 345.6" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2023-01-15T23:13:34.193198</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.6.3, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 345.6 
+L 460.8 345.6 
+L 460.8 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 57.6 307.584 
+L 414.72 307.584 
+L 414.72 41.472 
+L 57.6 41.472 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="m5350ac4717" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m5350ac4717" x="73.832727" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 0.0 -->
+      <g transform="translate(65.881165 322.182437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-2e" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#m5350ac4717" x="114.414545" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 2.5 -->
+      <g transform="translate(106.462983 322.182437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#m5350ac4717" x="154.996364" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 5.0 -->
+      <g transform="translate(147.044801 322.182437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-35"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m5350ac4717" x="195.578182" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 7.5 -->
+      <g transform="translate(187.626619 322.182437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-37"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#m5350ac4717" x="236.16" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 10.0 -->
+      <g transform="translate(225.027188 322.182437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m5350ac4717" x="276.741818" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 12.5 -->
+      <g transform="translate(265.609006 322.182437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#m5350ac4717" x="317.323636" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 15.0 -->
+      <g transform="translate(306.190824 322.182437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m5350ac4717" x="357.905455" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 17.5 -->
+      <g transform="translate(346.772642 322.182437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#m5350ac4717" x="398.487273" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 20.0 -->
+      <g transform="translate(387.35446 322.182437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_10">
+      <defs>
+       <path id="m83d85873e2" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m83d85873e2" x="57.6" y="295.751039" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- −1.00 -->
+      <g transform="translate(19.954687 299.550258) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-2212" d="M 678 2272 
+L 4684 2272 
+L 4684 1741 
+L 678 1741 
+L 678 2272 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-31" x="83.789062"/>
+       <use xlink:href="#DejaVuSans-2e" x="147.412109"/>
+       <use xlink:href="#DejaVuSans-30" x="179.199219"/>
+       <use xlink:href="#DejaVuSans-30" x="242.822266"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_11">
+      <g>
+       <use xlink:href="#m83d85873e2" x="57.6" y="265.478022" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- −0.75 -->
+      <g transform="translate(19.954687 269.277241) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-30" x="83.789062"/>
+       <use xlink:href="#DejaVuSans-2e" x="147.412109"/>
+       <use xlink:href="#DejaVuSans-37" x="179.199219"/>
+       <use xlink:href="#DejaVuSans-35" x="242.822266"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m83d85873e2" x="57.6" y="235.205006" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- −0.50 -->
+      <g transform="translate(19.954687 239.004225) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-30" x="83.789062"/>
+       <use xlink:href="#DejaVuSans-2e" x="147.412109"/>
+       <use xlink:href="#DejaVuSans-35" x="179.199219"/>
+       <use xlink:href="#DejaVuSans-30" x="242.822266"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#m83d85873e2" x="57.6" y="204.93199" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- −0.25 -->
+      <g transform="translate(19.954687 208.731208) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-30" x="83.789062"/>
+       <use xlink:href="#DejaVuSans-2e" x="147.412109"/>
+       <use xlink:href="#DejaVuSans-32" x="179.199219"/>
+       <use xlink:href="#DejaVuSans-35" x="242.822266"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m83d85873e2" x="57.6" y="174.658973" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- 0.00 -->
+      <g transform="translate(28.334375 178.458192) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_15">
+      <g>
+       <use xlink:href="#m83d85873e2" x="57.6" y="144.385957" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 0.25 -->
+      <g transform="translate(28.334375 148.185176) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m83d85873e2" x="57.6" y="114.112941" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- 0.50 -->
+      <g transform="translate(28.334375 117.912159) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_17">
+      <g>
+       <use xlink:href="#m83d85873e2" x="57.6" y="83.839924" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- 0.75 -->
+      <g transform="translate(28.334375 87.639143) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-37" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#m83d85873e2" x="57.6" y="53.566908" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_18">
+      <!-- 1.00 -->
+      <g transform="translate(28.334375 57.366127) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+       <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_19">
+    <path d="M 73.832727 174.658973 
+L 77.112066 150.361989 
+L 80.391405 127.053249 
+L 83.670744 105.680803 
+L 86.950083 87.113943 
+L 90.229421 72.107851 
+L 93.50876 61.272877 
+L 96.788099 55.049717 
+L 100.067438 53.691491 
+L 103.346777 57.253441 
+L 106.626116 65.59069 
+L 109.905455 78.364134 
+L 113.184793 95.054231 
+L 116.464132 114.982134 
+L 119.743471 137.337307 
+L 123.02281 161.210484 
+L 126.302149 185.630659 
+L 129.581488 209.604576 
+L 132.860826 232.157132 
+L 136.140165 252.371034 
+L 139.419504 269.42411 
+L 142.698843 282.622753 
+L 145.978182 291.430125 
+L 149.257521 295.488 
+L 152.53686 294.63133 
+L 155.816198 288.894958 
+L 159.095537 278.512204 
+L 162.374876 263.905371 
+L 165.654215 245.668569 
+L 168.933554 224.543556 
+L 172.212893 201.389559 
+L 175.492231 177.148335 
+L 178.77157 152.80586 
+L 182.050909 129.352228 
+L 185.330248 107.741382 
+L 188.609587 88.852313 
+L 191.888926 73.453304 
+L 195.168264 62.170689 
+L 198.447603 55.463372 
+L 201.726942 53.604163 
+L 205.006281 56.668682 
+L 208.28562 64.532286 
+L 211.564959 76.875132 
+L 214.844298 93.195194 
+L 218.123636 112.828677 
+L 221.402975 134.977018 
+L 224.682314 158.739364 
+L 227.961653 183.149218 
+L 231.240992 207.213743 
+L 234.520331 229.95415 
+L 237.799669 250.445506 
+L 241.079008 267.854355 
+L 244.358347 281.472617 
+L 247.637686 290.746389 
+L 250.917025 295.298475 
+L 254.196364 294.943723 
+L 257.475702 289.696564 
+L 260.755041 279.770418 
+L 264.03438 265.569017 
+L 267.313719 247.669982 
+L 270.593058 226.80133 
+L 273.872397 203.811863 
+L 277.151736 179.636645 
+L 280.431074 155.258967 
+L 283.710413 131.670356 
+L 286.989752 109.830245 
+L 290.269091 90.626949 
+L 293.54843 74.841533 
+L 296.827769 63.116046 
+L 300.107107 55.927406 
+L 303.386446 53.568 
+L 306.665785 56.133794 
+L 309.945124 63.520427 
+L 313.224463 75.427459 
+L 316.503802 91.370589 
+L 319.78314 110.701353 
+L 323.062479 132.6335 
+L 326.341818 156.274973 
+L 329.621157 180.664188 
+L 332.900496 204.80915 
+L 336.179835 227.727797 
+L 339.459174 248.487946 
+L 342.738512 266.24521 
+L 346.017851 280.277336 
+L 349.29719 290.013589 
+L 352.576529 295.05796 
+L 355.855868 295.205277 
+L 359.135207 290.449548 
+L 362.414545 280.984206 
+L 365.693884 267.19424 
+L 368.973223 249.640535 
+L 372.252562 229.037065 
+L 375.531901 206.221845 
+L 378.81124 182.122851 
+L 382.090579 157.720274 
+L 385.369917 134.006654 
+L 388.649256 111.946509 
+L 391.928595 92.437102 
+L 395.207934 76.27195 
+L 398.487273 64.108547 
+" clip-path="url(#pa6f745b81e)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5; stroke-linecap: square"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 57.6 307.584 
+L 57.6 41.472 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 414.72 307.584 
+L 414.72 41.472 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 57.6 307.584 
+L 414.72 307.584 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 57.6 41.472 
+L 414.72 41.472 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pa6f745b81e">
+   <rect x="57.6" y="41.472" width="357.12" height="266.112"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/example/__snapshots__/test_matplotlib.ambr
+++ b/example/__snapshots__/test_matplotlib.ambr
@@ -1,0 +1,3397 @@
+# name: test_matplotlib
+  '''
+  <?xml version="1.0" encoding="utf-8" standalone="no"?>
+  <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+    "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+  <svg xmlns:xlink="http://www.w3.org/1999/xlink" width="460.8pt" height="345.6pt" viewBox="0 0 460.8 345.6" xmlns="http://www.w3.org/2000/svg" version="1.1">
+   <metadata>
+    <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+     <cc:Work>
+      <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+      <dc:format>image/svg+xml</dc:format>
+      <dc:creator>
+       <cc:Agent>
+        <dc:title>Matplotlib v3.6.3, https://matplotlib.org/</dc:title>
+       </cc:Agent>
+      </dc:creator>
+     </cc:Work>
+    </rdf:RDF>
+   </metadata>
+   <defs>
+    <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+   </defs>
+   <g id="figure_1">
+    <g id="patch_1">
+     <path d="M 0 345.6 
+  L 460.8 345.6 
+  L 460.8 0 
+  L 0 0 
+  z
+  " style="fill: #ffffff"/>
+    </g>
+    <g id="axes_1">
+     <g id="patch_2">
+      <path d="M 57.6 307.584 
+  L 414.72 307.584 
+  L 414.72 41.472 
+  L 57.6 41.472 
+  z
+  " style="fill: #ffffff"/>
+     </g>
+     <g id="matplotlib.axis_1">
+      <g id="xtick_1">
+       <g id="line2d_1">
+        <defs>
+         <path id="m067c08e0d7" d="M 0 0 
+  L 0 3.5 
+  " style="stroke: #000000; stroke-width: 0.8"/>
+        </defs>
+        <g>
+         <use xlink:href="#m067c08e0d7" x="73.832727" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_1">
+        <!-- 0.0 -->
+        <g transform="translate(65.881165 322.182437) scale(0.1 -0.1)">
+         <defs>
+          <path id="DejaVuSans-30" d="M 2034 4250 
+  Q 1547 4250 1301 3770 
+  Q 1056 3291 1056 2328 
+  Q 1056 1369 1301 889 
+  Q 1547 409 2034 409 
+  Q 2525 409 2770 889 
+  Q 3016 1369 3016 2328 
+  Q 3016 3291 2770 3770 
+  Q 2525 4250 2034 4250 
+  z
+  M 2034 4750 
+  Q 2819 4750 3233 4129 
+  Q 3647 3509 3647 2328 
+  Q 3647 1150 3233 529 
+  Q 2819 -91 2034 -91 
+  Q 1250 -91 836 529 
+  Q 422 1150 422 2328 
+  Q 422 3509 836 4129 
+  Q 1250 4750 2034 4750 
+  z
+  " transform="scale(0.015625)"/>
+          <path id="DejaVuSans-2e" d="M 684 794 
+  L 1344 794 
+  L 1344 0 
+  L 684 0 
+  L 684 794 
+  z
+  " transform="scale(0.015625)"/>
+         </defs>
+         <use xlink:href="#DejaVuSans-30"/>
+         <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+         <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+        </g>
+       </g>
+      </g>
+      <g id="xtick_2">
+       <g id="line2d_2">
+        <g>
+         <use xlink:href="#m067c08e0d7" x="114.414545" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_2">
+        <!-- 2.5 -->
+        <g transform="translate(106.462983 322.182437) scale(0.1 -0.1)">
+         <defs>
+          <path id="DejaVuSans-32" d="M 1228 531 
+  L 3431 531 
+  L 3431 0 
+  L 469 0 
+  L 469 531 
+  Q 828 903 1448 1529 
+  Q 2069 2156 2228 2338 
+  Q 2531 2678 2651 2914 
+  Q 2772 3150 2772 3378 
+  Q 2772 3750 2511 3984 
+  Q 2250 4219 1831 4219 
+  Q 1534 4219 1204 4116 
+  Q 875 4013 500 3803 
+  L 500 4441 
+  Q 881 4594 1212 4672 
+  Q 1544 4750 1819 4750 
+  Q 2544 4750 2975 4387 
+  Q 3406 4025 3406 3419 
+  Q 3406 3131 3298 2873 
+  Q 3191 2616 2906 2266 
+  Q 2828 2175 2409 1742 
+  Q 1991 1309 1228 531 
+  z
+  " transform="scale(0.015625)"/>
+          <path id="DejaVuSans-35" d="M 691 4666 
+  L 3169 4666 
+  L 3169 4134 
+  L 1269 4134 
+  L 1269 2991 
+  Q 1406 3038 1543 3061 
+  Q 1681 3084 1819 3084 
+  Q 2600 3084 3056 2656 
+  Q 3513 2228 3513 1497 
+  Q 3513 744 3044 326 
+  Q 2575 -91 1722 -91 
+  Q 1428 -91 1123 -41 
+  Q 819 9 494 109 
+  L 494 744 
+  Q 775 591 1075 516 
+  Q 1375 441 1709 441 
+  Q 2250 441 2565 725 
+  Q 2881 1009 2881 1497 
+  Q 2881 1984 2565 2268 
+  Q 2250 2553 1709 2553 
+  Q 1456 2553 1204 2497 
+  Q 953 2441 691 2322 
+  L 691 4666 
+  z
+  " transform="scale(0.015625)"/>
+         </defs>
+         <use xlink:href="#DejaVuSans-32"/>
+         <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+         <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+        </g>
+       </g>
+      </g>
+      <g id="xtick_3">
+       <g id="line2d_3">
+        <g>
+         <use xlink:href="#m067c08e0d7" x="154.996364" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_3">
+        <!-- 5.0 -->
+        <g transform="translate(147.044801 322.182437) scale(0.1 -0.1)">
+         <use xlink:href="#DejaVuSans-35"/>
+         <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+         <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+        </g>
+       </g>
+      </g>
+      <g id="xtick_4">
+       <g id="line2d_4">
+        <g>
+         <use xlink:href="#m067c08e0d7" x="195.578182" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_4">
+        <!-- 7.5 -->
+        <g transform="translate(187.626619 322.182437) scale(0.1 -0.1)">
+         <defs>
+          <path id="DejaVuSans-37" d="M 525 4666 
+  L 3525 4666 
+  L 3525 4397 
+  L 1831 0 
+  L 1172 0 
+  L 2766 4134 
+  L 525 4134 
+  L 525 4666 
+  z
+  " transform="scale(0.015625)"/>
+         </defs>
+         <use xlink:href="#DejaVuSans-37"/>
+         <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+         <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+        </g>
+       </g>
+      </g>
+      <g id="xtick_5">
+       <g id="line2d_5">
+        <g>
+         <use xlink:href="#m067c08e0d7" x="236.16" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_5">
+        <!-- 10.0 -->
+        <g transform="translate(225.027188 322.182437) scale(0.1 -0.1)">
+         <defs>
+          <path id="DejaVuSans-31" d="M 794 531 
+  L 1825 531 
+  L 1825 4091 
+  L 703 3866 
+  L 703 4441 
+  L 1819 4666 
+  L 2450 4666 
+  L 2450 531 
+  L 3481 531 
+  L 3481 0 
+  L 794 0 
+  L 794 531 
+  z
+  " transform="scale(0.015625)"/>
+         </defs>
+         <use xlink:href="#DejaVuSans-31"/>
+         <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+         <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+         <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+        </g>
+       </g>
+      </g>
+      <g id="xtick_6">
+       <g id="line2d_6">
+        <g>
+         <use xlink:href="#m067c08e0d7" x="276.741818" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_6">
+        <!-- 12.5 -->
+        <g transform="translate(265.609006 322.182437) scale(0.1 -0.1)">
+         <use xlink:href="#DejaVuSans-31"/>
+         <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+         <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+         <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+        </g>
+       </g>
+      </g>
+      <g id="xtick_7">
+       <g id="line2d_7">
+        <g>
+         <use xlink:href="#m067c08e0d7" x="317.323636" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_7">
+        <!-- 15.0 -->
+        <g transform="translate(306.190824 322.182437) scale(0.1 -0.1)">
+         <use xlink:href="#DejaVuSans-31"/>
+         <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+         <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+         <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+        </g>
+       </g>
+      </g>
+      <g id="xtick_8">
+       <g id="line2d_8">
+        <g>
+         <use xlink:href="#m067c08e0d7" x="357.905455" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_8">
+        <!-- 17.5 -->
+        <g transform="translate(346.772642 322.182437) scale(0.1 -0.1)">
+         <use xlink:href="#DejaVuSans-31"/>
+         <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+         <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+         <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+        </g>
+       </g>
+      </g>
+      <g id="xtick_9">
+       <g id="line2d_9">
+        <g>
+         <use xlink:href="#m067c08e0d7" x="398.487273" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_9">
+        <!-- 20.0 -->
+        <g transform="translate(387.35446 322.182437) scale(0.1 -0.1)">
+         <use xlink:href="#DejaVuSans-32"/>
+         <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+         <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+         <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+        </g>
+       </g>
+      </g>
+      <g id="text_10">
+       <!-- x -->
+       <g transform="translate(233.200625 335.860562) scale(0.1 -0.1)">
+        <defs>
+         <path id="DejaVuSans-78" d="M 3513 3500 
+  L 2247 1797 
+  L 3578 0 
+  L 2900 0 
+  L 1881 1375 
+  L 863 0 
+  L 184 0 
+  L 1544 1831 
+  L 300 3500 
+  L 978 3500 
+  L 1906 2253 
+  L 2834 3500 
+  L 3513 3500 
+  z
+  " transform="scale(0.015625)"/>
+        </defs>
+        <use xlink:href="#DejaVuSans-78"/>
+       </g>
+      </g>
+     </g>
+     <g id="matplotlib.axis_2">
+      <g id="ytick_1">
+       <g id="line2d_10">
+        <defs>
+         <path id="m054f990ef5" d="M 0 0 
+  L -3.5 0 
+  " style="stroke: #000000; stroke-width: 0.8"/>
+        </defs>
+        <g>
+         <use xlink:href="#m054f990ef5" x="57.6" y="295.751039" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_11">
+        <!-- −1.00 -->
+        <g transform="translate(19.954687 299.550258) scale(0.1 -0.1)">
+         <defs>
+          <path id="DejaVuSans-2212" d="M 678 2272 
+  L 4684 2272 
+  L 4684 1741 
+  L 678 1741 
+  L 678 2272 
+  z
+  " transform="scale(0.015625)"/>
+         </defs>
+         <use xlink:href="#DejaVuSans-2212"/>
+         <use xlink:href="#DejaVuSans-31" x="83.789062"/>
+         <use xlink:href="#DejaVuSans-2e" x="147.412109"/>
+         <use xlink:href="#DejaVuSans-30" x="179.199219"/>
+         <use xlink:href="#DejaVuSans-30" x="242.822266"/>
+        </g>
+       </g>
+      </g>
+      <g id="ytick_2">
+       <g id="line2d_11">
+        <g>
+         <use xlink:href="#m054f990ef5" x="57.6" y="265.478022" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_12">
+        <!-- −0.75 -->
+        <g transform="translate(19.954687 269.277241) scale(0.1 -0.1)">
+         <use xlink:href="#DejaVuSans-2212"/>
+         <use xlink:href="#DejaVuSans-30" x="83.789062"/>
+         <use xlink:href="#DejaVuSans-2e" x="147.412109"/>
+         <use xlink:href="#DejaVuSans-37" x="179.199219"/>
+         <use xlink:href="#DejaVuSans-35" x="242.822266"/>
+        </g>
+       </g>
+      </g>
+      <g id="ytick_3">
+       <g id="line2d_12">
+        <g>
+         <use xlink:href="#m054f990ef5" x="57.6" y="235.205006" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_13">
+        <!-- −0.50 -->
+        <g transform="translate(19.954687 239.004225) scale(0.1 -0.1)">
+         <use xlink:href="#DejaVuSans-2212"/>
+         <use xlink:href="#DejaVuSans-30" x="83.789062"/>
+         <use xlink:href="#DejaVuSans-2e" x="147.412109"/>
+         <use xlink:href="#DejaVuSans-35" x="179.199219"/>
+         <use xlink:href="#DejaVuSans-30" x="242.822266"/>
+        </g>
+       </g>
+      </g>
+      <g id="ytick_4">
+       <g id="line2d_13">
+        <g>
+         <use xlink:href="#m054f990ef5" x="57.6" y="204.93199" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_14">
+        <!-- −0.25 -->
+        <g transform="translate(19.954687 208.731208) scale(0.1 -0.1)">
+         <use xlink:href="#DejaVuSans-2212"/>
+         <use xlink:href="#DejaVuSans-30" x="83.789062"/>
+         <use xlink:href="#DejaVuSans-2e" x="147.412109"/>
+         <use xlink:href="#DejaVuSans-32" x="179.199219"/>
+         <use xlink:href="#DejaVuSans-35" x="242.822266"/>
+        </g>
+       </g>
+      </g>
+      <g id="ytick_5">
+       <g id="line2d_14">
+        <g>
+         <use xlink:href="#m054f990ef5" x="57.6" y="174.658973" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_15">
+        <!-- 0.00 -->
+        <g transform="translate(28.334375 178.458192) scale(0.1 -0.1)">
+         <use xlink:href="#DejaVuSans-30"/>
+         <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+         <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+         <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+        </g>
+       </g>
+      </g>
+      <g id="ytick_6">
+       <g id="line2d_15">
+        <g>
+         <use xlink:href="#m054f990ef5" x="57.6" y="144.385957" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_16">
+        <!-- 0.25 -->
+        <g transform="translate(28.334375 148.185176) scale(0.1 -0.1)">
+         <use xlink:href="#DejaVuSans-30"/>
+         <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+         <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+         <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+        </g>
+       </g>
+      </g>
+      <g id="ytick_7">
+       <g id="line2d_16">
+        <g>
+         <use xlink:href="#m054f990ef5" x="57.6" y="114.112941" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_17">
+        <!-- 0.50 -->
+        <g transform="translate(28.334375 117.912159) scale(0.1 -0.1)">
+         <use xlink:href="#DejaVuSans-30"/>
+         <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+         <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+         <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+        </g>
+       </g>
+      </g>
+      <g id="ytick_8">
+       <g id="line2d_17">
+        <g>
+         <use xlink:href="#m054f990ef5" x="57.6" y="83.839924" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_18">
+        <!-- 0.75 -->
+        <g transform="translate(28.334375 87.639143) scale(0.1 -0.1)">
+         <use xlink:href="#DejaVuSans-30"/>
+         <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+         <use xlink:href="#DejaVuSans-37" x="95.410156"/>
+         <use xlink:href="#DejaVuSans-35" x="159.033203"/>
+        </g>
+       </g>
+      </g>
+      <g id="ytick_9">
+       <g id="line2d_18">
+        <g>
+         <use xlink:href="#m054f990ef5" x="57.6" y="53.566908" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_19">
+        <!-- 1.00 -->
+        <g transform="translate(28.334375 57.366127) scale(0.1 -0.1)">
+         <use xlink:href="#DejaVuSans-31"/>
+         <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+         <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+         <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+        </g>
+       </g>
+      </g>
+      <g id="text_20">
+       <!-- sin(x) -->
+       <g transform="translate(13.875 188.551437) rotate(-90) scale(0.1 -0.1)">
+        <defs>
+         <path id="DejaVuSans-73" d="M 2834 3397 
+  L 2834 2853 
+  Q 2591 2978 2328 3040 
+  Q 2066 3103 1784 3103 
+  Q 1356 3103 1142 2972 
+  Q 928 2841 928 2578 
+  Q 928 2378 1081 2264 
+  Q 1234 2150 1697 2047 
+  L 1894 2003 
+  Q 2506 1872 2764 1633 
+  Q 3022 1394 3022 966 
+  Q 3022 478 2636 193 
+  Q 2250 -91 1575 -91 
+  Q 1294 -91 989 -36 
+  Q 684 19 347 128 
+  L 347 722 
+  Q 666 556 975 473 
+  Q 1284 391 1588 391 
+  Q 1994 391 2212 530 
+  Q 2431 669 2431 922 
+  Q 2431 1156 2273 1281 
+  Q 2116 1406 1581 1522 
+  L 1381 1569 
+  Q 847 1681 609 1914 
+  Q 372 2147 372 2553 
+  Q 372 3047 722 3315 
+  Q 1072 3584 1716 3584 
+  Q 2034 3584 2315 3537 
+  Q 2597 3491 2834 3397 
+  z
+  " transform="scale(0.015625)"/>
+         <path id="DejaVuSans-69" d="M 603 3500 
+  L 1178 3500 
+  L 1178 0 
+  L 603 0 
+  L 603 3500 
+  z
+  M 603 4863 
+  L 1178 4863 
+  L 1178 4134 
+  L 603 4134 
+  L 603 4863 
+  z
+  " transform="scale(0.015625)"/>
+         <path id="DejaVuSans-6e" d="M 3513 2113 
+  L 3513 0 
+  L 2938 0 
+  L 2938 2094 
+  Q 2938 2591 2744 2837 
+  Q 2550 3084 2163 3084 
+  Q 1697 3084 1428 2787 
+  Q 1159 2491 1159 1978 
+  L 1159 0 
+  L 581 0 
+  L 581 3500 
+  L 1159 3500 
+  L 1159 2956 
+  Q 1366 3272 1645 3428 
+  Q 1925 3584 2291 3584 
+  Q 2894 3584 3203 3211 
+  Q 3513 2838 3513 2113 
+  z
+  " transform="scale(0.015625)"/>
+         <path id="DejaVuSans-28" d="M 1984 4856 
+  Q 1566 4138 1362 3434 
+  Q 1159 2731 1159 2009 
+  Q 1159 1288 1364 580 
+  Q 1569 -128 1984 -844 
+  L 1484 -844 
+  Q 1016 -109 783 600 
+  Q 550 1309 550 2009 
+  Q 550 2706 781 3412 
+  Q 1013 4119 1484 4856 
+  L 1984 4856 
+  z
+  " transform="scale(0.015625)"/>
+         <path id="DejaVuSans-29" d="M 513 4856 
+  L 1013 4856 
+  Q 1481 4119 1714 3412 
+  Q 1947 2706 1947 2009 
+  Q 1947 1309 1714 600 
+  Q 1481 -109 1013 -844 
+  L 513 -844 
+  Q 928 -128 1133 580 
+  Q 1338 1288 1338 2009 
+  Q 1338 2731 1133 3434 
+  Q 928 4138 513 4856 
+  z
+  " transform="scale(0.015625)"/>
+        </defs>
+        <use xlink:href="#DejaVuSans-73"/>
+        <use xlink:href="#DejaVuSans-69" x="52.099609"/>
+        <use xlink:href="#DejaVuSans-6e" x="79.882812"/>
+        <use xlink:href="#DejaVuSans-28" x="143.261719"/>
+        <use xlink:href="#DejaVuSans-78" x="182.275391"/>
+        <use xlink:href="#DejaVuSans-29" x="241.455078"/>
+       </g>
+      </g>
+     </g>
+     <g id="line2d_19">
+      <path d="M 73.832727 174.658973 
+  L 77.112066 150.361989 
+  L 80.391405 127.053249 
+  L 83.670744 105.680803 
+  L 86.950083 87.113943 
+  L 90.229421 72.107851 
+  L 93.50876 61.272877 
+  L 96.788099 55.049717 
+  L 100.067438 53.691491 
+  L 103.346777 57.253441 
+  L 106.626116 65.59069 
+  L 109.905455 78.364134 
+  L 113.184793 95.054231 
+  L 116.464132 114.982134 
+  L 119.743471 137.337307 
+  L 123.02281 161.210484 
+  L 126.302149 185.630659 
+  L 129.581488 209.604576 
+  L 132.860826 232.157132 
+  L 136.140165 252.371034 
+  L 139.419504 269.42411 
+  L 142.698843 282.622753 
+  L 145.978182 291.430125 
+  L 149.257521 295.488 
+  L 152.53686 294.63133 
+  L 155.816198 288.894958 
+  L 159.095537 278.512204 
+  L 162.374876 263.905371 
+  L 165.654215 245.668569 
+  L 168.933554 224.543556 
+  L 172.212893 201.389559 
+  L 175.492231 177.148335 
+  L 178.77157 152.80586 
+  L 182.050909 129.352228 
+  L 185.330248 107.741382 
+  L 188.609587 88.852313 
+  L 191.888926 73.453304 
+  L 195.168264 62.170689 
+  L 198.447603 55.463372 
+  L 201.726942 53.604163 
+  L 205.006281 56.668682 
+  L 208.28562 64.532286 
+  L 211.564959 76.875132 
+  L 214.844298 93.195194 
+  L 218.123636 112.828677 
+  L 221.402975 134.977018 
+  L 224.682314 158.739364 
+  L 227.961653 183.149218 
+  L 231.240992 207.213743 
+  L 234.520331 229.95415 
+  L 237.799669 250.445506 
+  L 241.079008 267.854355 
+  L 244.358347 281.472617 
+  L 247.637686 290.746389 
+  L 250.917025 295.298475 
+  L 254.196364 294.943723 
+  L 257.475702 289.696564 
+  L 260.755041 279.770418 
+  L 264.03438 265.569017 
+  L 267.313719 247.669982 
+  L 270.593058 226.80133 
+  L 273.872397 203.811863 
+  L 277.151736 179.636645 
+  L 280.431074 155.258967 
+  L 283.710413 131.670356 
+  L 286.989752 109.830245 
+  L 290.269091 90.626949 
+  L 293.54843 74.841533 
+  L 296.827769 63.116046 
+  L 300.107107 55.927406 
+  L 303.386446 53.568 
+  L 306.665785 56.133794 
+  L 309.945124 63.520427 
+  L 313.224463 75.427459 
+  L 316.503802 91.370589 
+  L 319.78314 110.701353 
+  L 323.062479 132.6335 
+  L 326.341818 156.274973 
+  L 329.621157 180.664188 
+  L 332.900496 204.80915 
+  L 336.179835 227.727797 
+  L 339.459174 248.487946 
+  L 342.738512 266.24521 
+  L 346.017851 280.277336 
+  L 349.29719 290.013589 
+  L 352.576529 295.05796 
+  L 355.855868 295.205277 
+  L 359.135207 290.449548 
+  L 362.414545 280.984206 
+  L 365.693884 267.19424 
+  L 368.973223 249.640535 
+  L 372.252562 229.037065 
+  L 375.531901 206.221845 
+  L 378.81124 182.122851 
+  L 382.090579 157.720274 
+  L 385.369917 134.006654 
+  L 388.649256 111.946509 
+  L 391.928595 92.437102 
+  L 395.207934 76.27195 
+  L 398.487273 64.108547 
+  " clip-path="url(#pb8778e6b03)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5; stroke-linecap: square"/>
+     </g>
+     <g id="patch_3">
+      <path d="M 57.6 307.584 
+  L 57.6 41.472 
+  " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+     </g>
+     <g id="patch_4">
+      <path d="M 414.72 307.584 
+  L 414.72 41.472 
+  " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+     </g>
+     <g id="patch_5">
+      <path d="M 57.6 307.584 
+  L 414.72 307.584 
+  " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+     </g>
+     <g id="patch_6">
+      <path d="M 57.6 41.472 
+  L 414.72 41.472 
+  " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+     </g>
+     <g id="text_21">
+      <!-- This is a plot -->
+      <g transform="translate(198.210938 35.472) scale(0.12 -0.12)">
+       <defs>
+        <path id="DejaVuSans-54" d="M -19 4666 
+  L 3928 4666 
+  L 3928 4134 
+  L 2272 4134 
+  L 2272 0 
+  L 1638 0 
+  L 1638 4134 
+  L -19 4134 
+  L -19 4666 
+  z
+  " transform="scale(0.015625)"/>
+        <path id="DejaVuSans-68" d="M 3513 2113 
+  L 3513 0 
+  L 2938 0 
+  L 2938 2094 
+  Q 2938 2591 2744 2837 
+  Q 2550 3084 2163 3084 
+  Q 1697 3084 1428 2787 
+  Q 1159 2491 1159 1978 
+  L 1159 0 
+  L 581 0 
+  L 581 4863 
+  L 1159 4863 
+  L 1159 2956 
+  Q 1366 3272 1645 3428 
+  Q 1925 3584 2291 3584 
+  Q 2894 3584 3203 3211 
+  Q 3513 2838 3513 2113 
+  z
+  " transform="scale(0.015625)"/>
+        <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-61" d="M 2194 1759 
+  Q 1497 1759 1228 1600 
+  Q 959 1441 959 1056 
+  Q 959 750 1161 570 
+  Q 1363 391 1709 391 
+  Q 2188 391 2477 730 
+  Q 2766 1069 2766 1631 
+  L 2766 1759 
+  L 2194 1759 
+  z
+  M 3341 1997 
+  L 3341 0 
+  L 2766 0 
+  L 2766 531 
+  Q 2569 213 2275 61 
+  Q 1981 -91 1556 -91 
+  Q 1019 -91 701 211 
+  Q 384 513 384 1019 
+  Q 384 1609 779 1909 
+  Q 1175 2209 1959 2209 
+  L 2766 2209 
+  L 2766 2266 
+  Q 2766 2663 2505 2880 
+  Q 2244 3097 1772 3097 
+  Q 1472 3097 1187 3025 
+  Q 903 2953 641 2809 
+  L 641 3341 
+  Q 956 3463 1253 3523 
+  Q 1550 3584 1831 3584 
+  Q 2591 3584 2966 3190 
+  Q 3341 2797 3341 1997 
+  z
+  " transform="scale(0.015625)"/>
+        <path id="DejaVuSans-70" d="M 1159 525 
+  L 1159 -1331 
+  L 581 -1331 
+  L 581 3500 
+  L 1159 3500 
+  L 1159 2969 
+  Q 1341 3281 1617 3432 
+  Q 1894 3584 2278 3584 
+  Q 2916 3584 3314 3078 
+  Q 3713 2572 3713 1747 
+  Q 3713 922 3314 415 
+  Q 2916 -91 2278 -91 
+  Q 1894 -91 1617 61 
+  Q 1341 213 1159 525 
+  z
+  M 3116 1747 
+  Q 3116 2381 2855 2742 
+  Q 2594 3103 2138 3103 
+  Q 1681 3103 1420 2742 
+  Q 1159 2381 1159 1747 
+  Q 1159 1113 1420 752 
+  Q 1681 391 2138 391 
+  Q 2594 391 2855 752 
+  Q 3116 1113 3116 1747 
+  z
+  " transform="scale(0.015625)"/>
+        <path id="DejaVuSans-6c" d="M 603 4863 
+  L 1178 4863 
+  L 1178 0 
+  L 603 0 
+  L 603 4863 
+  z
+  " transform="scale(0.015625)"/>
+        <path id="DejaVuSans-6f" d="M 1959 3097 
+  Q 1497 3097 1228 2736 
+  Q 959 2375 959 1747 
+  Q 959 1119 1226 758 
+  Q 1494 397 1959 397 
+  Q 2419 397 2687 759 
+  Q 2956 1122 2956 1747 
+  Q 2956 2369 2687 2733 
+  Q 2419 3097 1959 3097 
+  z
+  M 1959 3584 
+  Q 2709 3584 3137 3096 
+  Q 3566 2609 3566 1747 
+  Q 3566 888 3137 398 
+  Q 2709 -91 1959 -91 
+  Q 1206 -91 779 398 
+  Q 353 888 353 1747 
+  Q 353 2609 779 3096 
+  Q 1206 3584 1959 3584 
+  z
+  " transform="scale(0.015625)"/>
+        <path id="DejaVuSans-74" d="M 1172 4494 
+  L 1172 3500 
+  L 2356 3500 
+  L 2356 3053 
+  L 1172 3053 
+  L 1172 1153 
+  Q 1172 725 1289 603 
+  Q 1406 481 1766 481 
+  L 2356 481 
+  L 2356 0 
+  L 1766 0 
+  Q 1100 0 847 248 
+  Q 594 497 594 1153 
+  L 594 3053 
+  L 172 3053 
+  L 172 3500 
+  L 594 3500 
+  L 594 4494 
+  L 1172 4494 
+  z
+  " transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-54"/>
+       <use xlink:href="#DejaVuSans-68" x="61.083984"/>
+       <use xlink:href="#DejaVuSans-69" x="124.462891"/>
+       <use xlink:href="#DejaVuSans-73" x="152.246094"/>
+       <use xlink:href="#DejaVuSans-20" x="204.345703"/>
+       <use xlink:href="#DejaVuSans-69" x="236.132812"/>
+       <use xlink:href="#DejaVuSans-73" x="263.916016"/>
+       <use xlink:href="#DejaVuSans-20" x="316.015625"/>
+       <use xlink:href="#DejaVuSans-61" x="347.802734"/>
+       <use xlink:href="#DejaVuSans-20" x="409.082031"/>
+       <use xlink:href="#DejaVuSans-70" x="440.869141"/>
+       <use xlink:href="#DejaVuSans-6c" x="504.345703"/>
+       <use xlink:href="#DejaVuSans-6f" x="532.128906"/>
+       <use xlink:href="#DejaVuSans-74" x="593.310547"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <defs>
+    <clipPath id="pb8778e6b03">
+     <rect x="57.6" y="41.472" width="357.12" height="266.112"/>
+    </clipPath>
+   </defs>
+  </svg>
+  
+  '''
+# ---
+# name: test_matplotlib_bar
+  '''
+  <?xml version="1.0" encoding="utf-8" standalone="no"?>
+  <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+    "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+  <svg xmlns:xlink="http://www.w3.org/1999/xlink" width="460.8pt" height="345.6pt" viewBox="0 0 460.8 345.6" xmlns="http://www.w3.org/2000/svg" version="1.1">
+   <metadata>
+    <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+     <cc:Work>
+      <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+      <dc:format>image/svg+xml</dc:format>
+      <dc:creator>
+       <cc:Agent>
+        <dc:title>Matplotlib v3.6.3, https://matplotlib.org/</dc:title>
+       </cc:Agent>
+      </dc:creator>
+     </cc:Work>
+    </rdf:RDF>
+   </metadata>
+   <defs>
+    <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+   </defs>
+   <g id="figure_1">
+    <g id="patch_1">
+     <path d="M 0 345.6 
+  L 460.8 345.6 
+  L 460.8 0 
+  L 0 0 
+  z
+  " style="fill: #ffffff"/>
+    </g>
+    <g id="axes_1">
+     <g id="patch_2">
+      <path d="M 57.6 307.584 
+  L 414.72 307.584 
+  L 414.72 41.472 
+  L 57.6 41.472 
+  z
+  " style="fill: #ffffff"/>
+     </g>
+     <g id="patch_3">
+      <path d="M 73.832727 307.584 
+  L 127.941818 307.584 
+  L 127.941818 307.584 
+  L 73.832727 307.584 
+  z
+  " clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+     </g>
+     <g id="patch_4">
+      <path d="M 141.469091 307.584 
+  L 195.578182 307.584 
+  L 195.578182 244.224 
+  L 141.469091 244.224 
+  z
+  " clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+     </g>
+     <g id="patch_5">
+      <path d="M 209.105455 307.584 
+  L 263.214545 307.584 
+  L 263.214545 180.864 
+  L 209.105455 180.864 
+  z
+  " clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+     </g>
+     <g id="patch_6">
+      <path d="M 276.741818 307.584 
+  L 330.850909 307.584 
+  L 330.850909 117.504 
+  L 276.741818 117.504 
+  z
+  " clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+     </g>
+     <g id="patch_7">
+      <path d="M 344.378182 307.584 
+  L 398.487273 307.584 
+  L 398.487273 54.144 
+  L 344.378182 54.144 
+  z
+  " clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+     </g>
+     <g id="matplotlib.axis_1">
+      <g id="xtick_1">
+       <g id="line2d_1">
+        <defs>
+         <path id="m067c08e0d7" d="M 0 0 
+  L 0 3.5 
+  " style="stroke: #000000; stroke-width: 0.8"/>
+        </defs>
+        <g>
+         <use xlink:href="#m067c08e0d7" x="100.887273" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_1">
+        <!-- 0 -->
+        <g transform="translate(97.706023 322.182437) scale(0.1 -0.1)">
+         <defs>
+          <path id="DejaVuSans-30" d="M 2034 4250 
+  Q 1547 4250 1301 3770 
+  Q 1056 3291 1056 2328 
+  Q 1056 1369 1301 889 
+  Q 1547 409 2034 409 
+  Q 2525 409 2770 889 
+  Q 3016 1369 3016 2328 
+  Q 3016 3291 2770 3770 
+  Q 2525 4250 2034 4250 
+  z
+  M 2034 4750 
+  Q 2819 4750 3233 4129 
+  Q 3647 3509 3647 2328 
+  Q 3647 1150 3233 529 
+  Q 2819 -91 2034 -91 
+  Q 1250 -91 836 529 
+  Q 422 1150 422 2328 
+  Q 422 3509 836 4129 
+  Q 1250 4750 2034 4750 
+  z
+  " transform="scale(0.015625)"/>
+         </defs>
+         <use xlink:href="#DejaVuSans-30"/>
+        </g>
+       </g>
+      </g>
+      <g id="xtick_2">
+       <g id="line2d_2">
+        <g>
+         <use xlink:href="#m067c08e0d7" x="168.523636" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_2">
+        <!-- 1 -->
+        <g transform="translate(165.342386 322.182437) scale(0.1 -0.1)">
+         <defs>
+          <path id="DejaVuSans-31" d="M 794 531 
+  L 1825 531 
+  L 1825 4091 
+  L 703 3866 
+  L 703 4441 
+  L 1819 4666 
+  L 2450 4666 
+  L 2450 531 
+  L 3481 531 
+  L 3481 0 
+  L 794 0 
+  L 794 531 
+  z
+  " transform="scale(0.015625)"/>
+         </defs>
+         <use xlink:href="#DejaVuSans-31"/>
+        </g>
+       </g>
+      </g>
+      <g id="xtick_3">
+       <g id="line2d_3">
+        <g>
+         <use xlink:href="#m067c08e0d7" x="236.16" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_3">
+        <!-- 2 -->
+        <g transform="translate(232.97875 322.182437) scale(0.1 -0.1)">
+         <defs>
+          <path id="DejaVuSans-32" d="M 1228 531 
+  L 3431 531 
+  L 3431 0 
+  L 469 0 
+  L 469 531 
+  Q 828 903 1448 1529 
+  Q 2069 2156 2228 2338 
+  Q 2531 2678 2651 2914 
+  Q 2772 3150 2772 3378 
+  Q 2772 3750 2511 3984 
+  Q 2250 4219 1831 4219 
+  Q 1534 4219 1204 4116 
+  Q 875 4013 500 3803 
+  L 500 4441 
+  Q 881 4594 1212 4672 
+  Q 1544 4750 1819 4750 
+  Q 2544 4750 2975 4387 
+  Q 3406 4025 3406 3419 
+  Q 3406 3131 3298 2873 
+  Q 3191 2616 2906 2266 
+  Q 2828 2175 2409 1742 
+  Q 1991 1309 1228 531 
+  z
+  " transform="scale(0.015625)"/>
+         </defs>
+         <use xlink:href="#DejaVuSans-32"/>
+        </g>
+       </g>
+      </g>
+      <g id="xtick_4">
+       <g id="line2d_4">
+        <g>
+         <use xlink:href="#m067c08e0d7" x="303.796364" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_4">
+        <!-- 3 -->
+        <g transform="translate(300.615114 322.182437) scale(0.1 -0.1)">
+         <defs>
+          <path id="DejaVuSans-33" d="M 2597 2516 
+  Q 3050 2419 3304 2112 
+  Q 3559 1806 3559 1356 
+  Q 3559 666 3084 287 
+  Q 2609 -91 1734 -91 
+  Q 1441 -91 1130 -33 
+  Q 819 25 488 141 
+  L 488 750 
+  Q 750 597 1062 519 
+  Q 1375 441 1716 441 
+  Q 2309 441 2620 675 
+  Q 2931 909 2931 1356 
+  Q 2931 1769 2642 2001 
+  Q 2353 2234 1838 2234 
+  L 1294 2234 
+  L 1294 2753 
+  L 1863 2753 
+  Q 2328 2753 2575 2939 
+  Q 2822 3125 2822 3475 
+  Q 2822 3834 2567 4026 
+  Q 2313 4219 1838 4219 
+  Q 1578 4219 1281 4162 
+  Q 984 4106 628 3988 
+  L 628 4550 
+  Q 988 4650 1302 4700 
+  Q 1616 4750 1894 4750 
+  Q 2613 4750 3031 4423 
+  Q 3450 4097 3450 3541 
+  Q 3450 3153 3228 2886 
+  Q 3006 2619 2597 2516 
+  z
+  " transform="scale(0.015625)"/>
+         </defs>
+         <use xlink:href="#DejaVuSans-33"/>
+        </g>
+       </g>
+      </g>
+      <g id="xtick_5">
+       <g id="line2d_5">
+        <g>
+         <use xlink:href="#m067c08e0d7" x="371.432727" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_5">
+        <!-- 4 -->
+        <g transform="translate(368.251477 322.182437) scale(0.1 -0.1)">
+         <defs>
+          <path id="DejaVuSans-34" d="M 2419 4116 
+  L 825 1625 
+  L 2419 1625 
+  L 2419 4116 
+  z
+  M 2253 4666 
+  L 3047 4666 
+  L 3047 1625 
+  L 3713 1625 
+  L 3713 1100 
+  L 3047 1100 
+  L 3047 0 
+  L 2419 0 
+  L 2419 1100 
+  L 313 1100 
+  L 313 1709 
+  L 2253 4666 
+  z
+  " transform="scale(0.015625)"/>
+         </defs>
+         <use xlink:href="#DejaVuSans-34"/>
+        </g>
+       </g>
+      </g>
+      <g id="text_6">
+       <!-- x -->
+       <g transform="translate(233.200625 335.860562) scale(0.1 -0.1)">
+        <defs>
+         <path id="DejaVuSans-78" d="M 3513 3500 
+  L 2247 1797 
+  L 3578 0 
+  L 2900 0 
+  L 1881 1375 
+  L 863 0 
+  L 184 0 
+  L 1544 1831 
+  L 300 3500 
+  L 978 3500 
+  L 1906 2253 
+  L 2834 3500 
+  L 3513 3500 
+  z
+  " transform="scale(0.015625)"/>
+        </defs>
+        <use xlink:href="#DejaVuSans-78"/>
+       </g>
+      </g>
+     </g>
+     <g id="matplotlib.axis_2">
+      <g id="ytick_1">
+       <g id="line2d_6">
+        <defs>
+         <path id="m054f990ef5" d="M 0 0 
+  L -3.5 0 
+  " style="stroke: #000000; stroke-width: 0.8"/>
+        </defs>
+        <g>
+         <use xlink:href="#m054f990ef5" x="57.6" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_7">
+        <!-- 0.0 -->
+        <g transform="translate(34.696875 311.383219) scale(0.1 -0.1)">
+         <defs>
+          <path id="DejaVuSans-2e" d="M 684 794 
+  L 1344 794 
+  L 1344 0 
+  L 684 0 
+  L 684 794 
+  z
+  " transform="scale(0.015625)"/>
+         </defs>
+         <use xlink:href="#DejaVuSans-30"/>
+         <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+         <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+        </g>
+       </g>
+      </g>
+      <g id="ytick_2">
+       <g id="line2d_7">
+        <g>
+         <use xlink:href="#m054f990ef5" x="57.6" y="275.904" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_8">
+        <!-- 0.5 -->
+        <g transform="translate(34.696875 279.703219) scale(0.1 -0.1)">
+         <defs>
+          <path id="DejaVuSans-35" d="M 691 4666 
+  L 3169 4666 
+  L 3169 4134 
+  L 1269 4134 
+  L 1269 2991 
+  Q 1406 3038 1543 3061 
+  Q 1681 3084 1819 3084 
+  Q 2600 3084 3056 2656 
+  Q 3513 2228 3513 1497 
+  Q 3513 744 3044 326 
+  Q 2575 -91 1722 -91 
+  Q 1428 -91 1123 -41 
+  Q 819 9 494 109 
+  L 494 744 
+  Q 775 591 1075 516 
+  Q 1375 441 1709 441 
+  Q 2250 441 2565 725 
+  Q 2881 1009 2881 1497 
+  Q 2881 1984 2565 2268 
+  Q 2250 2553 1709 2553 
+  Q 1456 2553 1204 2497 
+  Q 953 2441 691 2322 
+  L 691 4666 
+  z
+  " transform="scale(0.015625)"/>
+         </defs>
+         <use xlink:href="#DejaVuSans-30"/>
+         <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+         <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+        </g>
+       </g>
+      </g>
+      <g id="ytick_3">
+       <g id="line2d_8">
+        <g>
+         <use xlink:href="#m054f990ef5" x="57.6" y="244.224" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_9">
+        <!-- 1.0 -->
+        <g transform="translate(34.696875 248.023219) scale(0.1 -0.1)">
+         <use xlink:href="#DejaVuSans-31"/>
+         <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+         <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+        </g>
+       </g>
+      </g>
+      <g id="ytick_4">
+       <g id="line2d_9">
+        <g>
+         <use xlink:href="#m054f990ef5" x="57.6" y="212.544" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_10">
+        <!-- 1.5 -->
+        <g transform="translate(34.696875 216.343219) scale(0.1 -0.1)">
+         <use xlink:href="#DejaVuSans-31"/>
+         <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+         <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+        </g>
+       </g>
+      </g>
+      <g id="ytick_5">
+       <g id="line2d_10">
+        <g>
+         <use xlink:href="#m054f990ef5" x="57.6" y="180.864" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_11">
+        <!-- 2.0 -->
+        <g transform="translate(34.696875 184.663219) scale(0.1 -0.1)">
+         <use xlink:href="#DejaVuSans-32"/>
+         <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+         <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+        </g>
+       </g>
+      </g>
+      <g id="ytick_6">
+       <g id="line2d_11">
+        <g>
+         <use xlink:href="#m054f990ef5" x="57.6" y="149.184" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_12">
+        <!-- 2.5 -->
+        <g transform="translate(34.696875 152.983219) scale(0.1 -0.1)">
+         <use xlink:href="#DejaVuSans-32"/>
+         <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+         <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+        </g>
+       </g>
+      </g>
+      <g id="ytick_7">
+       <g id="line2d_12">
+        <g>
+         <use xlink:href="#m054f990ef5" x="57.6" y="117.504" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_13">
+        <!-- 3.0 -->
+        <g transform="translate(34.696875 121.303219) scale(0.1 -0.1)">
+         <use xlink:href="#DejaVuSans-33"/>
+         <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+         <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+        </g>
+       </g>
+      </g>
+      <g id="ytick_8">
+       <g id="line2d_13">
+        <g>
+         <use xlink:href="#m054f990ef5" x="57.6" y="85.824" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_14">
+        <!-- 3.5 -->
+        <g transform="translate(34.696875 89.623219) scale(0.1 -0.1)">
+         <use xlink:href="#DejaVuSans-33"/>
+         <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+         <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+        </g>
+       </g>
+      </g>
+      <g id="ytick_9">
+       <g id="line2d_14">
+        <g>
+         <use xlink:href="#m054f990ef5" x="57.6" y="54.144" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_15">
+        <!-- 4.0 -->
+        <g transform="translate(34.696875 57.943219) scale(0.1 -0.1)">
+         <use xlink:href="#DejaVuSans-34"/>
+         <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+         <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+        </g>
+       </g>
+      </g>
+      <g id="text_16">
+       <!-- y -->
+       <g transform="translate(28.617188 177.487375) rotate(-90) scale(0.1 -0.1)">
+        <defs>
+         <path id="DejaVuSans-79" d="M 2059 -325 
+  Q 1816 -950 1584 -1140 
+  Q 1353 -1331 966 -1331 
+  L 506 -1331 
+  L 506 -850 
+  L 844 -850 
+  Q 1081 -850 1212 -737 
+  Q 1344 -625 1503 -206 
+  L 1606 56 
+  L 191 3500 
+  L 800 3500 
+  L 1894 763 
+  L 2988 3500 
+  L 3597 3500 
+  L 2059 -325 
+  z
+  " transform="scale(0.015625)"/>
+        </defs>
+        <use xlink:href="#DejaVuSans-79"/>
+       </g>
+      </g>
+     </g>
+     <g id="patch_8">
+      <path d="M 57.6 307.584 
+  L 57.6 41.472 
+  " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+     </g>
+     <g id="patch_9">
+      <path d="M 414.72 307.584 
+  L 414.72 41.472 
+  " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+     </g>
+     <g id="patch_10">
+      <path d="M 57.6 307.584 
+  L 414.72 307.584 
+  " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+     </g>
+     <g id="patch_11">
+      <path d="M 57.6 41.472 
+  L 414.72 41.472 
+  " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+     </g>
+     <g id="text_17">
+      <!-- This is a bar -->
+      <g transform="translate(199.757812 35.472) scale(0.12 -0.12)">
+       <defs>
+        <path id="DejaVuSans-54" d="M -19 4666 
+  L 3928 4666 
+  L 3928 4134 
+  L 2272 4134 
+  L 2272 0 
+  L 1638 0 
+  L 1638 4134 
+  L -19 4134 
+  L -19 4666 
+  z
+  " transform="scale(0.015625)"/>
+        <path id="DejaVuSans-68" d="M 3513 2113 
+  L 3513 0 
+  L 2938 0 
+  L 2938 2094 
+  Q 2938 2591 2744 2837 
+  Q 2550 3084 2163 3084 
+  Q 1697 3084 1428 2787 
+  Q 1159 2491 1159 1978 
+  L 1159 0 
+  L 581 0 
+  L 581 4863 
+  L 1159 4863 
+  L 1159 2956 
+  Q 1366 3272 1645 3428 
+  Q 1925 3584 2291 3584 
+  Q 2894 3584 3203 3211 
+  Q 3513 2838 3513 2113 
+  z
+  " transform="scale(0.015625)"/>
+        <path id="DejaVuSans-69" d="M 603 3500 
+  L 1178 3500 
+  L 1178 0 
+  L 603 0 
+  L 603 3500 
+  z
+  M 603 4863 
+  L 1178 4863 
+  L 1178 4134 
+  L 603 4134 
+  L 603 4863 
+  z
+  " transform="scale(0.015625)"/>
+        <path id="DejaVuSans-73" d="M 2834 3397 
+  L 2834 2853 
+  Q 2591 2978 2328 3040 
+  Q 2066 3103 1784 3103 
+  Q 1356 3103 1142 2972 
+  Q 928 2841 928 2578 
+  Q 928 2378 1081 2264 
+  Q 1234 2150 1697 2047 
+  L 1894 2003 
+  Q 2506 1872 2764 1633 
+  Q 3022 1394 3022 966 
+  Q 3022 478 2636 193 
+  Q 2250 -91 1575 -91 
+  Q 1294 -91 989 -36 
+  Q 684 19 347 128 
+  L 347 722 
+  Q 666 556 975 473 
+  Q 1284 391 1588 391 
+  Q 1994 391 2212 530 
+  Q 2431 669 2431 922 
+  Q 2431 1156 2273 1281 
+  Q 2116 1406 1581 1522 
+  L 1381 1569 
+  Q 847 1681 609 1914 
+  Q 372 2147 372 2553 
+  Q 372 3047 722 3315 
+  Q 1072 3584 1716 3584 
+  Q 2034 3584 2315 3537 
+  Q 2597 3491 2834 3397 
+  z
+  " transform="scale(0.015625)"/>
+        <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-61" d="M 2194 1759 
+  Q 1497 1759 1228 1600 
+  Q 959 1441 959 1056 
+  Q 959 750 1161 570 
+  Q 1363 391 1709 391 
+  Q 2188 391 2477 730 
+  Q 2766 1069 2766 1631 
+  L 2766 1759 
+  L 2194 1759 
+  z
+  M 3341 1997 
+  L 3341 0 
+  L 2766 0 
+  L 2766 531 
+  Q 2569 213 2275 61 
+  Q 1981 -91 1556 -91 
+  Q 1019 -91 701 211 
+  Q 384 513 384 1019 
+  Q 384 1609 779 1909 
+  Q 1175 2209 1959 2209 
+  L 2766 2209 
+  L 2766 2266 
+  Q 2766 2663 2505 2880 
+  Q 2244 3097 1772 3097 
+  Q 1472 3097 1187 3025 
+  Q 903 2953 641 2809 
+  L 641 3341 
+  Q 956 3463 1253 3523 
+  Q 1550 3584 1831 3584 
+  Q 2591 3584 2966 3190 
+  Q 3341 2797 3341 1997 
+  z
+  " transform="scale(0.015625)"/>
+        <path id="DejaVuSans-62" d="M 3116 1747 
+  Q 3116 2381 2855 2742 
+  Q 2594 3103 2138 3103 
+  Q 1681 3103 1420 2742 
+  Q 1159 2381 1159 1747 
+  Q 1159 1113 1420 752 
+  Q 1681 391 2138 391 
+  Q 2594 391 2855 752 
+  Q 3116 1113 3116 1747 
+  z
+  M 1159 2969 
+  Q 1341 3281 1617 3432 
+  Q 1894 3584 2278 3584 
+  Q 2916 3584 3314 3078 
+  Q 3713 2572 3713 1747 
+  Q 3713 922 3314 415 
+  Q 2916 -91 2278 -91 
+  Q 1894 -91 1617 61 
+  Q 1341 213 1159 525 
+  L 1159 0 
+  L 581 0 
+  L 581 4863 
+  L 1159 4863 
+  L 1159 2969 
+  z
+  " transform="scale(0.015625)"/>
+        <path id="DejaVuSans-72" d="M 2631 2963 
+  Q 2534 3019 2420 3045 
+  Q 2306 3072 2169 3072 
+  Q 1681 3072 1420 2755 
+  Q 1159 2438 1159 1844 
+  L 1159 0 
+  L 581 0 
+  L 581 3500 
+  L 1159 3500 
+  L 1159 2956 
+  Q 1341 3275 1631 3429 
+  Q 1922 3584 2338 3584 
+  Q 2397 3584 2469 3576 
+  Q 2541 3569 2628 3553 
+  L 2631 2963 
+  z
+  " transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-54"/>
+       <use xlink:href="#DejaVuSans-68" x="61.083984"/>
+       <use xlink:href="#DejaVuSans-69" x="124.462891"/>
+       <use xlink:href="#DejaVuSans-73" x="152.246094"/>
+       <use xlink:href="#DejaVuSans-20" x="204.345703"/>
+       <use xlink:href="#DejaVuSans-69" x="236.132812"/>
+       <use xlink:href="#DejaVuSans-73" x="263.916016"/>
+       <use xlink:href="#DejaVuSans-20" x="316.015625"/>
+       <use xlink:href="#DejaVuSans-61" x="347.802734"/>
+       <use xlink:href="#DejaVuSans-20" x="409.082031"/>
+       <use xlink:href="#DejaVuSans-62" x="440.869141"/>
+       <use xlink:href="#DejaVuSans-61" x="504.345703"/>
+       <use xlink:href="#DejaVuSans-72" x="565.625"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <defs>
+    <clipPath id="pb8778e6b03">
+     <rect x="57.6" y="41.472" width="357.12" height="266.112"/>
+    </clipPath>
+   </defs>
+  </svg>
+  
+  '''
+# ---
+# name: test_matplotlib_hist
+  '''
+  <?xml version="1.0" encoding="utf-8" standalone="no"?>
+  <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+    "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+  <svg xmlns:xlink="http://www.w3.org/1999/xlink" width="460.8pt" height="345.6pt" viewBox="0 0 460.8 345.6" xmlns="http://www.w3.org/2000/svg" version="1.1">
+   <metadata>
+    <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+     <cc:Work>
+      <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+      <dc:format>image/svg+xml</dc:format>
+      <dc:creator>
+       <cc:Agent>
+        <dc:title>Matplotlib v3.6.3, https://matplotlib.org/</dc:title>
+       </cc:Agent>
+      </dc:creator>
+     </cc:Work>
+    </rdf:RDF>
+   </metadata>
+   <defs>
+    <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+   </defs>
+   <g id="figure_1">
+    <g id="patch_1">
+     <path d="M 0 345.6 
+  L 460.8 345.6 
+  L 460.8 0 
+  L 0 0 
+  z
+  " style="fill: #ffffff"/>
+    </g>
+    <g id="axes_1">
+     <g id="patch_2">
+      <path d="M 57.6 307.584 
+  L 414.72 307.584 
+  L 414.72 41.472 
+  L 57.6 41.472 
+  z
+  " style="fill: #ffffff"/>
+     </g>
+     <g id="patch_3">
+      <path d="M 73.832727 307.584 
+  L 90.065455 307.584 
+  L 90.065455 301.402537 
+  L 73.832727 301.402537 
+  z
+  " clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+     </g>
+     <g id="patch_4">
+      <path d="M 90.065455 307.584 
+  L 106.298182 307.584 
+  L 106.298182 295.221073 
+  L 90.065455 295.221073 
+  z
+  " clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+     </g>
+     <g id="patch_5">
+      <path d="M 106.298182 307.584 
+  L 122.530909 307.584 
+  L 122.530909 289.03961 
+  L 106.298182 289.03961 
+  z
+  " clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+     </g>
+     <g id="patch_6">
+      <path d="M 122.530909 307.584 
+  L 138.763636 307.584 
+  L 138.763636 284.918634 
+  L 122.530909 284.918634 
+  z
+  " clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+     </g>
+     <g id="patch_7">
+      <path d="M 138.763636 307.584 
+  L 154.996364 307.584 
+  L 154.996364 245.769366 
+  L 138.763636 245.769366 
+  z
+  " clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+     </g>
+     <g id="patch_8">
+      <path d="M 154.996364 307.584 
+  L 171.229091 307.584 
+  L 171.229091 225.164488 
+  L 154.996364 225.164488 
+  z
+  " clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+     </g>
+     <g id="patch_9">
+      <path d="M 171.229091 307.584 
+  L 187.461818 307.584 
+  L 187.461818 186.01522 
+  L 171.229091 186.01522 
+  z
+  " clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+     </g>
+     <g id="patch_10">
+      <path d="M 187.461818 307.584 
+  L 203.694545 307.584 
+  L 203.694545 128.321561 
+  L 187.461818 128.321561 
+  z
+  " clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+     </g>
+     <g id="patch_11">
+      <path d="M 203.694545 307.584 
+  L 219.927273 307.584 
+  L 219.927273 95.353756 
+  L 203.694545 95.353756 
+  z
+  " clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+     </g>
+     <g id="patch_12">
+      <path d="M 219.927273 307.584 
+  L 236.16 307.584 
+  L 236.16 72.68839 
+  L 219.927273 72.68839 
+  z
+  " clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+     </g>
+     <g id="patch_13">
+      <path d="M 236.16 307.584 
+  L 252.392727 307.584 
+  L 252.392727 68.567415 
+  L 236.16 68.567415 
+  z
+  " clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+     </g>
+     <g id="patch_14">
+      <path d="M 252.392727 307.584 
+  L 268.625455 307.584 
+  L 268.625455 54.144 
+  L 252.392727 54.144 
+  z
+  " clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+     </g>
+     <g id="patch_15">
+      <path d="M 268.625455 307.584 
+  L 284.858182 307.584 
+  L 284.858182 136.563512 
+  L 268.625455 136.563512 
+  z
+  " clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+     </g>
+     <g id="patch_16">
+      <path d="M 284.858182 307.584 
+  L 301.090909 307.584 
+  L 301.090909 148.926439 
+  L 284.858182 148.926439 
+  z
+  " clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+     </g>
+     <g id="patch_17">
+      <path d="M 301.090909 307.584 
+  L 317.323636 307.584 
+  L 317.323636 208.680585 
+  L 301.090909 208.680585 
+  z
+  " clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+     </g>
+     <g id="patch_18">
+      <path d="M 317.323636 307.584 
+  L 333.556364 307.584 
+  L 333.556364 229.285463 
+  L 317.323636 229.285463 
+  z
+  " clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+     </g>
+     <g id="patch_19">
+      <path d="M 333.556364 307.584 
+  L 349.789091 307.584 
+  L 349.789091 262.253268 
+  L 333.556364 262.253268 
+  z
+  " clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+     </g>
+     <g id="patch_20">
+      <path d="M 349.789091 307.584 
+  L 366.021818 307.584 
+  L 366.021818 274.616195 
+  L 349.789091 274.616195 
+  z
+  " clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+     </g>
+     <g id="patch_21">
+      <path d="M 366.021818 307.584 
+  L 382.254545 307.584 
+  L 382.254545 284.918634 
+  L 366.021818 284.918634 
+  z
+  " clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+     </g>
+     <g id="patch_22">
+      <path d="M 382.254545 307.584 
+  L 398.487273 307.584 
+  L 398.487273 299.342049 
+  L 382.254545 299.342049 
+  z
+  " clip-path="url(#pb8778e6b03)" style="fill: #1f77b4"/>
+     </g>
+     <g id="matplotlib.axis_1">
+      <g id="xtick_1">
+       <g id="line2d_1">
+        <defs>
+         <path id="m067c08e0d7" d="M 0 0 
+  L 0 3.5 
+  " style="stroke: #000000; stroke-width: 0.8"/>
+        </defs>
+        <g>
+         <use xlink:href="#m067c08e0d7" x="76.413135" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_1">
+        <!-- −3 -->
+        <g transform="translate(69.042041 322.182437) scale(0.1 -0.1)">
+         <defs>
+          <path id="DejaVuSans-2212" d="M 678 2272 
+  L 4684 2272 
+  L 4684 1741 
+  L 678 1741 
+  L 678 2272 
+  z
+  " transform="scale(0.015625)"/>
+          <path id="DejaVuSans-33" d="M 2597 2516 
+  Q 3050 2419 3304 2112 
+  Q 3559 1806 3559 1356 
+  Q 3559 666 3084 287 
+  Q 2609 -91 1734 -91 
+  Q 1441 -91 1130 -33 
+  Q 819 25 488 141 
+  L 488 750 
+  Q 750 597 1062 519 
+  Q 1375 441 1716 441 
+  Q 2309 441 2620 675 
+  Q 2931 909 2931 1356 
+  Q 2931 1769 2642 2001 
+  Q 2353 2234 1838 2234 
+  L 1294 2234 
+  L 1294 2753 
+  L 1863 2753 
+  Q 2328 2753 2575 2939 
+  Q 2822 3125 2822 3475 
+  Q 2822 3834 2567 4026 
+  Q 2313 4219 1838 4219 
+  Q 1578 4219 1281 4162 
+  Q 984 4106 628 3988 
+  L 628 4550 
+  Q 988 4650 1302 4700 
+  Q 1616 4750 1894 4750 
+  Q 2613 4750 3031 4423 
+  Q 3450 4097 3450 3541 
+  Q 3450 3153 3228 2886 
+  Q 3006 2619 2597 2516 
+  z
+  " transform="scale(0.015625)"/>
+         </defs>
+         <use xlink:href="#DejaVuSans-2212"/>
+         <use xlink:href="#DejaVuSans-33" x="83.789062"/>
+        </g>
+       </g>
+      </g>
+      <g id="xtick_2">
+       <g id="line2d_2">
+        <g>
+         <use xlink:href="#m067c08e0d7" x="132.335045" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_2">
+        <!-- −2 -->
+        <g transform="translate(124.963951 322.182437) scale(0.1 -0.1)">
+         <defs>
+          <path id="DejaVuSans-32" d="M 1228 531 
+  L 3431 531 
+  L 3431 0 
+  L 469 0 
+  L 469 531 
+  Q 828 903 1448 1529 
+  Q 2069 2156 2228 2338 
+  Q 2531 2678 2651 2914 
+  Q 2772 3150 2772 3378 
+  Q 2772 3750 2511 3984 
+  Q 2250 4219 1831 4219 
+  Q 1534 4219 1204 4116 
+  Q 875 4013 500 3803 
+  L 500 4441 
+  Q 881 4594 1212 4672 
+  Q 1544 4750 1819 4750 
+  Q 2544 4750 2975 4387 
+  Q 3406 4025 3406 3419 
+  Q 3406 3131 3298 2873 
+  Q 3191 2616 2906 2266 
+  Q 2828 2175 2409 1742 
+  Q 1991 1309 1228 531 
+  z
+  " transform="scale(0.015625)"/>
+         </defs>
+         <use xlink:href="#DejaVuSans-2212"/>
+         <use xlink:href="#DejaVuSans-32" x="83.789062"/>
+        </g>
+       </g>
+      </g>
+      <g id="xtick_3">
+       <g id="line2d_3">
+        <g>
+         <use xlink:href="#m067c08e0d7" x="188.256955" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_3">
+        <!-- −1 -->
+        <g transform="translate(180.885861 322.182437) scale(0.1 -0.1)">
+         <defs>
+          <path id="DejaVuSans-31" d="M 794 531 
+  L 1825 531 
+  L 1825 4091 
+  L 703 3866 
+  L 703 4441 
+  L 1819 4666 
+  L 2450 4666 
+  L 2450 531 
+  L 3481 531 
+  L 3481 0 
+  L 794 0 
+  L 794 531 
+  z
+  " transform="scale(0.015625)"/>
+         </defs>
+         <use xlink:href="#DejaVuSans-2212"/>
+         <use xlink:href="#DejaVuSans-31" x="83.789062"/>
+        </g>
+       </g>
+      </g>
+      <g id="xtick_4">
+       <g id="line2d_4">
+        <g>
+         <use xlink:href="#m067c08e0d7" x="244.178865" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_4">
+        <!-- 0 -->
+        <g transform="translate(240.997615 322.182437) scale(0.1 -0.1)">
+         <defs>
+          <path id="DejaVuSans-30" d="M 2034 4250 
+  Q 1547 4250 1301 3770 
+  Q 1056 3291 1056 2328 
+  Q 1056 1369 1301 889 
+  Q 1547 409 2034 409 
+  Q 2525 409 2770 889 
+  Q 3016 1369 3016 2328 
+  Q 3016 3291 2770 3770 
+  Q 2525 4250 2034 4250 
+  z
+  M 2034 4750 
+  Q 2819 4750 3233 4129 
+  Q 3647 3509 3647 2328 
+  Q 3647 1150 3233 529 
+  Q 2819 -91 2034 -91 
+  Q 1250 -91 836 529 
+  Q 422 1150 422 2328 
+  Q 422 3509 836 4129 
+  Q 1250 4750 2034 4750 
+  z
+  " transform="scale(0.015625)"/>
+         </defs>
+         <use xlink:href="#DejaVuSans-30"/>
+        </g>
+       </g>
+      </g>
+      <g id="xtick_5">
+       <g id="line2d_5">
+        <g>
+         <use xlink:href="#m067c08e0d7" x="300.100775" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_5">
+        <!-- 1 -->
+        <g transform="translate(296.919525 322.182437) scale(0.1 -0.1)">
+         <use xlink:href="#DejaVuSans-31"/>
+        </g>
+       </g>
+      </g>
+      <g id="xtick_6">
+       <g id="line2d_6">
+        <g>
+         <use xlink:href="#m067c08e0d7" x="356.022684" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_6">
+        <!-- 2 -->
+        <g transform="translate(352.841434 322.182437) scale(0.1 -0.1)">
+         <use xlink:href="#DejaVuSans-32"/>
+        </g>
+       </g>
+      </g>
+      <g id="xtick_7">
+       <g id="line2d_7">
+        <g>
+         <use xlink:href="#m067c08e0d7" x="411.944594" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_7">
+        <!-- 3 -->
+        <g transform="translate(408.763344 322.182437) scale(0.1 -0.1)">
+         <use xlink:href="#DejaVuSans-33"/>
+        </g>
+       </g>
+      </g>
+      <g id="text_8">
+       <!-- x -->
+       <g transform="translate(233.200625 335.860562) scale(0.1 -0.1)">
+        <defs>
+         <path id="DejaVuSans-78" d="M 3513 3500 
+  L 2247 1797 
+  L 3578 0 
+  L 2900 0 
+  L 1881 1375 
+  L 863 0 
+  L 184 0 
+  L 1544 1831 
+  L 300 3500 
+  L 978 3500 
+  L 1906 2253 
+  L 2834 3500 
+  L 3513 3500 
+  z
+  " transform="scale(0.015625)"/>
+        </defs>
+        <use xlink:href="#DejaVuSans-78"/>
+       </g>
+      </g>
+     </g>
+     <g id="matplotlib.axis_2">
+      <g id="ytick_1">
+       <g id="line2d_8">
+        <defs>
+         <path id="m054f990ef5" d="M 0 0 
+  L -3.5 0 
+  " style="stroke: #000000; stroke-width: 0.8"/>
+        </defs>
+        <g>
+         <use xlink:href="#m054f990ef5" x="57.6" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_9">
+        <!-- 0 -->
+        <g transform="translate(44.2375 311.383219) scale(0.1 -0.1)">
+         <use xlink:href="#DejaVuSans-30"/>
+        </g>
+       </g>
+      </g>
+      <g id="ytick_2">
+       <g id="line2d_9">
+        <g>
+         <use xlink:href="#m054f990ef5" x="57.6" y="266.374244" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_10">
+        <!-- 20 -->
+        <g transform="translate(37.875 270.173463) scale(0.1 -0.1)">
+         <use xlink:href="#DejaVuSans-32"/>
+         <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+        </g>
+       </g>
+      </g>
+      <g id="ytick_3">
+       <g id="line2d_10">
+        <g>
+         <use xlink:href="#m054f990ef5" x="57.6" y="225.164488" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_11">
+        <!-- 40 -->
+        <g transform="translate(37.875 228.963707) scale(0.1 -0.1)">
+         <defs>
+          <path id="DejaVuSans-34" d="M 2419 4116 
+  L 825 1625 
+  L 2419 1625 
+  L 2419 4116 
+  z
+  M 2253 4666 
+  L 3047 4666 
+  L 3047 1625 
+  L 3713 1625 
+  L 3713 1100 
+  L 3047 1100 
+  L 3047 0 
+  L 2419 0 
+  L 2419 1100 
+  L 313 1100 
+  L 313 1709 
+  L 2253 4666 
+  z
+  " transform="scale(0.015625)"/>
+         </defs>
+         <use xlink:href="#DejaVuSans-34"/>
+         <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+        </g>
+       </g>
+      </g>
+      <g id="ytick_4">
+       <g id="line2d_11">
+        <g>
+         <use xlink:href="#m054f990ef5" x="57.6" y="183.954732" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_12">
+        <!-- 60 -->
+        <g transform="translate(37.875 187.75395) scale(0.1 -0.1)">
+         <defs>
+          <path id="DejaVuSans-36" d="M 2113 2584 
+  Q 1688 2584 1439 2293 
+  Q 1191 2003 1191 1497 
+  Q 1191 994 1439 701 
+  Q 1688 409 2113 409 
+  Q 2538 409 2786 701 
+  Q 3034 994 3034 1497 
+  Q 3034 2003 2786 2293 
+  Q 2538 2584 2113 2584 
+  z
+  M 3366 4563 
+  L 3366 3988 
+  Q 3128 4100 2886 4159 
+  Q 2644 4219 2406 4219 
+  Q 1781 4219 1451 3797 
+  Q 1122 3375 1075 2522 
+  Q 1259 2794 1537 2939 
+  Q 1816 3084 2150 3084 
+  Q 2853 3084 3261 2657 
+  Q 3669 2231 3669 1497 
+  Q 3669 778 3244 343 
+  Q 2819 -91 2113 -91 
+  Q 1303 -91 875 529 
+  Q 447 1150 447 2328 
+  Q 447 3434 972 4092 
+  Q 1497 4750 2381 4750 
+  Q 2619 4750 2861 4703 
+  Q 3103 4656 3366 4563 
+  z
+  " transform="scale(0.015625)"/>
+         </defs>
+         <use xlink:href="#DejaVuSans-36"/>
+         <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+        </g>
+       </g>
+      </g>
+      <g id="ytick_5">
+       <g id="line2d_12">
+        <g>
+         <use xlink:href="#m054f990ef5" x="57.6" y="142.744976" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_13">
+        <!-- 80 -->
+        <g transform="translate(37.875 146.544194) scale(0.1 -0.1)">
+         <defs>
+          <path id="DejaVuSans-38" d="M 2034 2216 
+  Q 1584 2216 1326 1975 
+  Q 1069 1734 1069 1313 
+  Q 1069 891 1326 650 
+  Q 1584 409 2034 409 
+  Q 2484 409 2743 651 
+  Q 3003 894 3003 1313 
+  Q 3003 1734 2745 1975 
+  Q 2488 2216 2034 2216 
+  z
+  M 1403 2484 
+  Q 997 2584 770 2862 
+  Q 544 3141 544 3541 
+  Q 544 4100 942 4425 
+  Q 1341 4750 2034 4750 
+  Q 2731 4750 3128 4425 
+  Q 3525 4100 3525 3541 
+  Q 3525 3141 3298 2862 
+  Q 3072 2584 2669 2484 
+  Q 3125 2378 3379 2068 
+  Q 3634 1759 3634 1313 
+  Q 3634 634 3220 271 
+  Q 2806 -91 2034 -91 
+  Q 1263 -91 848 271 
+  Q 434 634 434 1313 
+  Q 434 1759 690 2068 
+  Q 947 2378 1403 2484 
+  z
+  M 1172 3481 
+  Q 1172 3119 1398 2916 
+  Q 1625 2713 2034 2713 
+  Q 2441 2713 2670 2916 
+  Q 2900 3119 2900 3481 
+  Q 2900 3844 2670 4047 
+  Q 2441 4250 2034 4250 
+  Q 1625 4250 1398 4047 
+  Q 1172 3844 1172 3481 
+  z
+  " transform="scale(0.015625)"/>
+         </defs>
+         <use xlink:href="#DejaVuSans-38"/>
+         <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+        </g>
+       </g>
+      </g>
+      <g id="ytick_6">
+       <g id="line2d_13">
+        <g>
+         <use xlink:href="#m054f990ef5" x="57.6" y="101.53522" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_14">
+        <!-- 100 -->
+        <g transform="translate(31.5125 105.334438) scale(0.1 -0.1)">
+         <use xlink:href="#DejaVuSans-31"/>
+         <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+         <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+        </g>
+       </g>
+      </g>
+      <g id="ytick_7">
+       <g id="line2d_14">
+        <g>
+         <use xlink:href="#m054f990ef5" x="57.6" y="60.325463" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_15">
+        <!-- 120 -->
+        <g transform="translate(31.5125 64.124682) scale(0.1 -0.1)">
+         <use xlink:href="#DejaVuSans-31"/>
+         <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+         <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+        </g>
+       </g>
+      </g>
+      <g id="text_16">
+       <!-- y (random) -->
+       <g transform="translate(25.432812 202.370187) rotate(-90) scale(0.1 -0.1)">
+        <defs>
+         <path id="DejaVuSans-79" d="M 2059 -325 
+  Q 1816 -950 1584 -1140 
+  Q 1353 -1331 966 -1331 
+  L 506 -1331 
+  L 506 -850 
+  L 844 -850 
+  Q 1081 -850 1212 -737 
+  Q 1344 -625 1503 -206 
+  L 1606 56 
+  L 191 3500 
+  L 800 3500 
+  L 1894 763 
+  L 2988 3500 
+  L 3597 3500 
+  L 2059 -325 
+  z
+  " transform="scale(0.015625)"/>
+         <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+         <path id="DejaVuSans-28" d="M 1984 4856 
+  Q 1566 4138 1362 3434 
+  Q 1159 2731 1159 2009 
+  Q 1159 1288 1364 580 
+  Q 1569 -128 1984 -844 
+  L 1484 -844 
+  Q 1016 -109 783 600 
+  Q 550 1309 550 2009 
+  Q 550 2706 781 3412 
+  Q 1013 4119 1484 4856 
+  L 1984 4856 
+  z
+  " transform="scale(0.015625)"/>
+         <path id="DejaVuSans-72" d="M 2631 2963 
+  Q 2534 3019 2420 3045 
+  Q 2306 3072 2169 3072 
+  Q 1681 3072 1420 2755 
+  Q 1159 2438 1159 1844 
+  L 1159 0 
+  L 581 0 
+  L 581 3500 
+  L 1159 3500 
+  L 1159 2956 
+  Q 1341 3275 1631 3429 
+  Q 1922 3584 2338 3584 
+  Q 2397 3584 2469 3576 
+  Q 2541 3569 2628 3553 
+  L 2631 2963 
+  z
+  " transform="scale(0.015625)"/>
+         <path id="DejaVuSans-61" d="M 2194 1759 
+  Q 1497 1759 1228 1600 
+  Q 959 1441 959 1056 
+  Q 959 750 1161 570 
+  Q 1363 391 1709 391 
+  Q 2188 391 2477 730 
+  Q 2766 1069 2766 1631 
+  L 2766 1759 
+  L 2194 1759 
+  z
+  M 3341 1997 
+  L 3341 0 
+  L 2766 0 
+  L 2766 531 
+  Q 2569 213 2275 61 
+  Q 1981 -91 1556 -91 
+  Q 1019 -91 701 211 
+  Q 384 513 384 1019 
+  Q 384 1609 779 1909 
+  Q 1175 2209 1959 2209 
+  L 2766 2209 
+  L 2766 2266 
+  Q 2766 2663 2505 2880 
+  Q 2244 3097 1772 3097 
+  Q 1472 3097 1187 3025 
+  Q 903 2953 641 2809 
+  L 641 3341 
+  Q 956 3463 1253 3523 
+  Q 1550 3584 1831 3584 
+  Q 2591 3584 2966 3190 
+  Q 3341 2797 3341 1997 
+  z
+  " transform="scale(0.015625)"/>
+         <path id="DejaVuSans-6e" d="M 3513 2113 
+  L 3513 0 
+  L 2938 0 
+  L 2938 2094 
+  Q 2938 2591 2744 2837 
+  Q 2550 3084 2163 3084 
+  Q 1697 3084 1428 2787 
+  Q 1159 2491 1159 1978 
+  L 1159 0 
+  L 581 0 
+  L 581 3500 
+  L 1159 3500 
+  L 1159 2956 
+  Q 1366 3272 1645 3428 
+  Q 1925 3584 2291 3584 
+  Q 2894 3584 3203 3211 
+  Q 3513 2838 3513 2113 
+  z
+  " transform="scale(0.015625)"/>
+         <path id="DejaVuSans-64" d="M 2906 2969 
+  L 2906 4863 
+  L 3481 4863 
+  L 3481 0 
+  L 2906 0 
+  L 2906 525 
+  Q 2725 213 2448 61 
+  Q 2172 -91 1784 -91 
+  Q 1150 -91 751 415 
+  Q 353 922 353 1747 
+  Q 353 2572 751 3078 
+  Q 1150 3584 1784 3584 
+  Q 2172 3584 2448 3432 
+  Q 2725 3281 2906 2969 
+  z
+  M 947 1747 
+  Q 947 1113 1208 752 
+  Q 1469 391 1925 391 
+  Q 2381 391 2643 752 
+  Q 2906 1113 2906 1747 
+  Q 2906 2381 2643 2742 
+  Q 2381 3103 1925 3103 
+  Q 1469 3103 1208 2742 
+  Q 947 2381 947 1747 
+  z
+  " transform="scale(0.015625)"/>
+         <path id="DejaVuSans-6f" d="M 1959 3097 
+  Q 1497 3097 1228 2736 
+  Q 959 2375 959 1747 
+  Q 959 1119 1226 758 
+  Q 1494 397 1959 397 
+  Q 2419 397 2687 759 
+  Q 2956 1122 2956 1747 
+  Q 2956 2369 2687 2733 
+  Q 2419 3097 1959 3097 
+  z
+  M 1959 3584 
+  Q 2709 3584 3137 3096 
+  Q 3566 2609 3566 1747 
+  Q 3566 888 3137 398 
+  Q 2709 -91 1959 -91 
+  Q 1206 -91 779 398 
+  Q 353 888 353 1747 
+  Q 353 2609 779 3096 
+  Q 1206 3584 1959 3584 
+  z
+  " transform="scale(0.015625)"/>
+         <path id="DejaVuSans-6d" d="M 3328 2828 
+  Q 3544 3216 3844 3400 
+  Q 4144 3584 4550 3584 
+  Q 5097 3584 5394 3201 
+  Q 5691 2819 5691 2113 
+  L 5691 0 
+  L 5113 0 
+  L 5113 2094 
+  Q 5113 2597 4934 2840 
+  Q 4756 3084 4391 3084 
+  Q 3944 3084 3684 2787 
+  Q 3425 2491 3425 1978 
+  L 3425 0 
+  L 2847 0 
+  L 2847 2094 
+  Q 2847 2600 2669 2842 
+  Q 2491 3084 2119 3084 
+  Q 1678 3084 1418 2786 
+  Q 1159 2488 1159 1978 
+  L 1159 0 
+  L 581 0 
+  L 581 3500 
+  L 1159 3500 
+  L 1159 2956 
+  Q 1356 3278 1631 3431 
+  Q 1906 3584 2284 3584 
+  Q 2666 3584 2933 3390 
+  Q 3200 3197 3328 2828 
+  z
+  " transform="scale(0.015625)"/>
+         <path id="DejaVuSans-29" d="M 513 4856 
+  L 1013 4856 
+  Q 1481 4119 1714 3412 
+  Q 1947 2706 1947 2009 
+  Q 1947 1309 1714 600 
+  Q 1481 -109 1013 -844 
+  L 513 -844 
+  Q 928 -128 1133 580 
+  Q 1338 1288 1338 2009 
+  Q 1338 2731 1133 3434 
+  Q 928 4138 513 4856 
+  z
+  " transform="scale(0.015625)"/>
+        </defs>
+        <use xlink:href="#DejaVuSans-79"/>
+        <use xlink:href="#DejaVuSans-20" x="59.179688"/>
+        <use xlink:href="#DejaVuSans-28" x="90.966797"/>
+        <use xlink:href="#DejaVuSans-72" x="129.980469"/>
+        <use xlink:href="#DejaVuSans-61" x="171.09375"/>
+        <use xlink:href="#DejaVuSans-6e" x="232.373047"/>
+        <use xlink:href="#DejaVuSans-64" x="295.751953"/>
+        <use xlink:href="#DejaVuSans-6f" x="359.228516"/>
+        <use xlink:href="#DejaVuSans-6d" x="420.410156"/>
+        <use xlink:href="#DejaVuSans-29" x="517.822266"/>
+       </g>
+      </g>
+     </g>
+     <g id="patch_23">
+      <path d="M 57.6 307.584 
+  L 57.6 41.472 
+  " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+     </g>
+     <g id="patch_24">
+      <path d="M 414.72 307.584 
+  L 414.72 41.472 
+  " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+     </g>
+     <g id="patch_25">
+      <path d="M 57.6 307.584 
+  L 414.72 307.584 
+  " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+     </g>
+     <g id="patch_26">
+      <path d="M 57.6 41.472 
+  L 414.72 41.472 
+  " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+     </g>
+     <g id="text_17">
+      <!-- This is a histogram -->
+      <g transform="translate(179.295 35.472) scale(0.12 -0.12)">
+       <defs>
+        <path id="DejaVuSans-54" d="M -19 4666 
+  L 3928 4666 
+  L 3928 4134 
+  L 2272 4134 
+  L 2272 0 
+  L 1638 0 
+  L 1638 4134 
+  L -19 4134 
+  L -19 4666 
+  z
+  " transform="scale(0.015625)"/>
+        <path id="DejaVuSans-68" d="M 3513 2113 
+  L 3513 0 
+  L 2938 0 
+  L 2938 2094 
+  Q 2938 2591 2744 2837 
+  Q 2550 3084 2163 3084 
+  Q 1697 3084 1428 2787 
+  Q 1159 2491 1159 1978 
+  L 1159 0 
+  L 581 0 
+  L 581 4863 
+  L 1159 4863 
+  L 1159 2956 
+  Q 1366 3272 1645 3428 
+  Q 1925 3584 2291 3584 
+  Q 2894 3584 3203 3211 
+  Q 3513 2838 3513 2113 
+  z
+  " transform="scale(0.015625)"/>
+        <path id="DejaVuSans-69" d="M 603 3500 
+  L 1178 3500 
+  L 1178 0 
+  L 603 0 
+  L 603 3500 
+  z
+  M 603 4863 
+  L 1178 4863 
+  L 1178 4134 
+  L 603 4134 
+  L 603 4863 
+  z
+  " transform="scale(0.015625)"/>
+        <path id="DejaVuSans-73" d="M 2834 3397 
+  L 2834 2853 
+  Q 2591 2978 2328 3040 
+  Q 2066 3103 1784 3103 
+  Q 1356 3103 1142 2972 
+  Q 928 2841 928 2578 
+  Q 928 2378 1081 2264 
+  Q 1234 2150 1697 2047 
+  L 1894 2003 
+  Q 2506 1872 2764 1633 
+  Q 3022 1394 3022 966 
+  Q 3022 478 2636 193 
+  Q 2250 -91 1575 -91 
+  Q 1294 -91 989 -36 
+  Q 684 19 347 128 
+  L 347 722 
+  Q 666 556 975 473 
+  Q 1284 391 1588 391 
+  Q 1994 391 2212 530 
+  Q 2431 669 2431 922 
+  Q 2431 1156 2273 1281 
+  Q 2116 1406 1581 1522 
+  L 1381 1569 
+  Q 847 1681 609 1914 
+  Q 372 2147 372 2553 
+  Q 372 3047 722 3315 
+  Q 1072 3584 1716 3584 
+  Q 2034 3584 2315 3537 
+  Q 2597 3491 2834 3397 
+  z
+  " transform="scale(0.015625)"/>
+        <path id="DejaVuSans-74" d="M 1172 4494 
+  L 1172 3500 
+  L 2356 3500 
+  L 2356 3053 
+  L 1172 3053 
+  L 1172 1153 
+  Q 1172 725 1289 603 
+  Q 1406 481 1766 481 
+  L 2356 481 
+  L 2356 0 
+  L 1766 0 
+  Q 1100 0 847 248 
+  Q 594 497 594 1153 
+  L 594 3053 
+  L 172 3053 
+  L 172 3500 
+  L 594 3500 
+  L 594 4494 
+  L 1172 4494 
+  z
+  " transform="scale(0.015625)"/>
+        <path id="DejaVuSans-67" d="M 2906 1791 
+  Q 2906 2416 2648 2759 
+  Q 2391 3103 1925 3103 
+  Q 1463 3103 1205 2759 
+  Q 947 2416 947 1791 
+  Q 947 1169 1205 825 
+  Q 1463 481 1925 481 
+  Q 2391 481 2648 825 
+  Q 2906 1169 2906 1791 
+  z
+  M 3481 434 
+  Q 3481 -459 3084 -895 
+  Q 2688 -1331 1869 -1331 
+  Q 1566 -1331 1297 -1286 
+  Q 1028 -1241 775 -1147 
+  L 775 -588 
+  Q 1028 -725 1275 -790 
+  Q 1522 -856 1778 -856 
+  Q 2344 -856 2625 -561 
+  Q 2906 -266 2906 331 
+  L 2906 616 
+  Q 2728 306 2450 153 
+  Q 2172 0 1784 0 
+  Q 1141 0 747 490 
+  Q 353 981 353 1791 
+  Q 353 2603 747 3093 
+  Q 1141 3584 1784 3584 
+  Q 2172 3584 2450 3431 
+  Q 2728 3278 2906 2969 
+  L 2906 3500 
+  L 3481 3500 
+  L 3481 434 
+  z
+  " transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-54"/>
+       <use xlink:href="#DejaVuSans-68" x="61.083984"/>
+       <use xlink:href="#DejaVuSans-69" x="124.462891"/>
+       <use xlink:href="#DejaVuSans-73" x="152.246094"/>
+       <use xlink:href="#DejaVuSans-20" x="204.345703"/>
+       <use xlink:href="#DejaVuSans-69" x="236.132812"/>
+       <use xlink:href="#DejaVuSans-73" x="263.916016"/>
+       <use xlink:href="#DejaVuSans-20" x="316.015625"/>
+       <use xlink:href="#DejaVuSans-61" x="347.802734"/>
+       <use xlink:href="#DejaVuSans-20" x="409.082031"/>
+       <use xlink:href="#DejaVuSans-68" x="440.869141"/>
+       <use xlink:href="#DejaVuSans-69" x="504.248047"/>
+       <use xlink:href="#DejaVuSans-73" x="532.03125"/>
+       <use xlink:href="#DejaVuSans-74" x="584.130859"/>
+       <use xlink:href="#DejaVuSans-6f" x="623.339844"/>
+       <use xlink:href="#DejaVuSans-67" x="684.521484"/>
+       <use xlink:href="#DejaVuSans-72" x="747.998047"/>
+       <use xlink:href="#DejaVuSans-61" x="789.111328"/>
+       <use xlink:href="#DejaVuSans-6d" x="850.390625"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <defs>
+    <clipPath id="pb8778e6b03">
+     <rect x="57.6" y="41.472" width="357.12" height="266.112"/>
+    </clipPath>
+   </defs>
+  </svg>
+  
+  '''
+# ---
+# name: test_matplotlib_scatter
+  '''
+  <?xml version="1.0" encoding="utf-8" standalone="no"?>
+  <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+    "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+  <svg xmlns:xlink="http://www.w3.org/1999/xlink" width="460.8pt" height="345.6pt" viewBox="0 0 460.8 345.6" xmlns="http://www.w3.org/2000/svg" version="1.1">
+   <metadata>
+    <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+     <cc:Work>
+      <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+      <dc:format>image/svg+xml</dc:format>
+      <dc:creator>
+       <cc:Agent>
+        <dc:title>Matplotlib v3.6.3, https://matplotlib.org/</dc:title>
+       </cc:Agent>
+      </dc:creator>
+     </cc:Work>
+    </rdf:RDF>
+   </metadata>
+   <defs>
+    <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+   </defs>
+   <g id="figure_1">
+    <g id="patch_1">
+     <path d="M 0 345.6 
+  L 460.8 345.6 
+  L 460.8 0 
+  L 0 0 
+  z
+  " style="fill: #ffffff"/>
+    </g>
+    <g id="axes_1">
+     <g id="patch_2">
+      <path d="M 57.6 307.584 
+  L 414.72 307.584 
+  L 414.72 41.472 
+  L 57.6 41.472 
+  z
+  " style="fill: #ffffff"/>
+     </g>
+     <g id="PathCollection_1">
+      <defs>
+       <path id="me6cd846f7f" d="M 0 3 
+  C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
+  C 2.683901 1.55874 3 0.795609 3 0 
+  C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
+  C 1.55874 -2.683901 0.795609 -3 0 -3 
+  C -0.795609 -3 -1.55874 -2.683901 -2.12132 -2.12132 
+  C -2.683901 -1.55874 -3 -0.795609 -3 0 
+  C -3 0.795609 -2.683901 1.55874 -2.12132 2.12132 
+  C -1.55874 2.683901 -0.795609 3 0 3 
+  z
+  " style="stroke: #1f77b4"/>
+      </defs>
+      <g clip-path="url(#pb8778e6b03)">
+       <use xlink:href="#me6cd846f7f" x="73.832727" y="295.488" style="fill: #1f77b4; stroke: #1f77b4"/>
+       <use xlink:href="#me6cd846f7f" x="154.996364" y="235.008" style="fill: #1f77b4; stroke: #1f77b4"/>
+       <use xlink:href="#me6cd846f7f" x="236.16" y="174.528" style="fill: #1f77b4; stroke: #1f77b4"/>
+       <use xlink:href="#me6cd846f7f" x="317.323636" y="114.048" style="fill: #1f77b4; stroke: #1f77b4"/>
+       <use xlink:href="#me6cd846f7f" x="398.487273" y="53.568" style="fill: #1f77b4; stroke: #1f77b4"/>
+      </g>
+     </g>
+     <g id="matplotlib.axis_1">
+      <g id="xtick_1">
+       <g id="line2d_1">
+        <defs>
+         <path id="m067c08e0d7" d="M 0 0 
+  L 0 3.5 
+  " style="stroke: #000000; stroke-width: 0.8"/>
+        </defs>
+        <g>
+         <use xlink:href="#m067c08e0d7" x="73.832727" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_1">
+        <!-- 0.0 -->
+        <g transform="translate(65.881165 322.182437) scale(0.1 -0.1)">
+         <defs>
+          <path id="DejaVuSans-30" d="M 2034 4250 
+  Q 1547 4250 1301 3770 
+  Q 1056 3291 1056 2328 
+  Q 1056 1369 1301 889 
+  Q 1547 409 2034 409 
+  Q 2525 409 2770 889 
+  Q 3016 1369 3016 2328 
+  Q 3016 3291 2770 3770 
+  Q 2525 4250 2034 4250 
+  z
+  M 2034 4750 
+  Q 2819 4750 3233 4129 
+  Q 3647 3509 3647 2328 
+  Q 3647 1150 3233 529 
+  Q 2819 -91 2034 -91 
+  Q 1250 -91 836 529 
+  Q 422 1150 422 2328 
+  Q 422 3509 836 4129 
+  Q 1250 4750 2034 4750 
+  z
+  " transform="scale(0.015625)"/>
+          <path id="DejaVuSans-2e" d="M 684 794 
+  L 1344 794 
+  L 1344 0 
+  L 684 0 
+  L 684 794 
+  z
+  " transform="scale(0.015625)"/>
+         </defs>
+         <use xlink:href="#DejaVuSans-30"/>
+         <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+         <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+        </g>
+       </g>
+      </g>
+      <g id="xtick_2">
+       <g id="line2d_2">
+        <g>
+         <use xlink:href="#m067c08e0d7" x="114.414545" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_2">
+        <!-- 0.5 -->
+        <g transform="translate(106.462983 322.182437) scale(0.1 -0.1)">
+         <defs>
+          <path id="DejaVuSans-35" d="M 691 4666 
+  L 3169 4666 
+  L 3169 4134 
+  L 1269 4134 
+  L 1269 2991 
+  Q 1406 3038 1543 3061 
+  Q 1681 3084 1819 3084 
+  Q 2600 3084 3056 2656 
+  Q 3513 2228 3513 1497 
+  Q 3513 744 3044 326 
+  Q 2575 -91 1722 -91 
+  Q 1428 -91 1123 -41 
+  Q 819 9 494 109 
+  L 494 744 
+  Q 775 591 1075 516 
+  Q 1375 441 1709 441 
+  Q 2250 441 2565 725 
+  Q 2881 1009 2881 1497 
+  Q 2881 1984 2565 2268 
+  Q 2250 2553 1709 2553 
+  Q 1456 2553 1204 2497 
+  Q 953 2441 691 2322 
+  L 691 4666 
+  z
+  " transform="scale(0.015625)"/>
+         </defs>
+         <use xlink:href="#DejaVuSans-30"/>
+         <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+         <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+        </g>
+       </g>
+      </g>
+      <g id="xtick_3">
+       <g id="line2d_3">
+        <g>
+         <use xlink:href="#m067c08e0d7" x="154.996364" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_3">
+        <!-- 1.0 -->
+        <g transform="translate(147.044801 322.182437) scale(0.1 -0.1)">
+         <defs>
+          <path id="DejaVuSans-31" d="M 794 531 
+  L 1825 531 
+  L 1825 4091 
+  L 703 3866 
+  L 703 4441 
+  L 1819 4666 
+  L 2450 4666 
+  L 2450 531 
+  L 3481 531 
+  L 3481 0 
+  L 794 0 
+  L 794 531 
+  z
+  " transform="scale(0.015625)"/>
+         </defs>
+         <use xlink:href="#DejaVuSans-31"/>
+         <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+         <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+        </g>
+       </g>
+      </g>
+      <g id="xtick_4">
+       <g id="line2d_4">
+        <g>
+         <use xlink:href="#m067c08e0d7" x="195.578182" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_4">
+        <!-- 1.5 -->
+        <g transform="translate(187.626619 322.182437) scale(0.1 -0.1)">
+         <use xlink:href="#DejaVuSans-31"/>
+         <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+         <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+        </g>
+       </g>
+      </g>
+      <g id="xtick_5">
+       <g id="line2d_5">
+        <g>
+         <use xlink:href="#m067c08e0d7" x="236.16" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_5">
+        <!-- 2.0 -->
+        <g transform="translate(228.208438 322.182437) scale(0.1 -0.1)">
+         <defs>
+          <path id="DejaVuSans-32" d="M 1228 531 
+  L 3431 531 
+  L 3431 0 
+  L 469 0 
+  L 469 531 
+  Q 828 903 1448 1529 
+  Q 2069 2156 2228 2338 
+  Q 2531 2678 2651 2914 
+  Q 2772 3150 2772 3378 
+  Q 2772 3750 2511 3984 
+  Q 2250 4219 1831 4219 
+  Q 1534 4219 1204 4116 
+  Q 875 4013 500 3803 
+  L 500 4441 
+  Q 881 4594 1212 4672 
+  Q 1544 4750 1819 4750 
+  Q 2544 4750 2975 4387 
+  Q 3406 4025 3406 3419 
+  Q 3406 3131 3298 2873 
+  Q 3191 2616 2906 2266 
+  Q 2828 2175 2409 1742 
+  Q 1991 1309 1228 531 
+  z
+  " transform="scale(0.015625)"/>
+         </defs>
+         <use xlink:href="#DejaVuSans-32"/>
+         <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+         <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+        </g>
+       </g>
+      </g>
+      <g id="xtick_6">
+       <g id="line2d_6">
+        <g>
+         <use xlink:href="#m067c08e0d7" x="276.741818" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_6">
+        <!-- 2.5 -->
+        <g transform="translate(268.790256 322.182437) scale(0.1 -0.1)">
+         <use xlink:href="#DejaVuSans-32"/>
+         <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+         <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+        </g>
+       </g>
+      </g>
+      <g id="xtick_7">
+       <g id="line2d_7">
+        <g>
+         <use xlink:href="#m067c08e0d7" x="317.323636" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_7">
+        <!-- 3.0 -->
+        <g transform="translate(309.372074 322.182437) scale(0.1 -0.1)">
+         <defs>
+          <path id="DejaVuSans-33" d="M 2597 2516 
+  Q 3050 2419 3304 2112 
+  Q 3559 1806 3559 1356 
+  Q 3559 666 3084 287 
+  Q 2609 -91 1734 -91 
+  Q 1441 -91 1130 -33 
+  Q 819 25 488 141 
+  L 488 750 
+  Q 750 597 1062 519 
+  Q 1375 441 1716 441 
+  Q 2309 441 2620 675 
+  Q 2931 909 2931 1356 
+  Q 2931 1769 2642 2001 
+  Q 2353 2234 1838 2234 
+  L 1294 2234 
+  L 1294 2753 
+  L 1863 2753 
+  Q 2328 2753 2575 2939 
+  Q 2822 3125 2822 3475 
+  Q 2822 3834 2567 4026 
+  Q 2313 4219 1838 4219 
+  Q 1578 4219 1281 4162 
+  Q 984 4106 628 3988 
+  L 628 4550 
+  Q 988 4650 1302 4700 
+  Q 1616 4750 1894 4750 
+  Q 2613 4750 3031 4423 
+  Q 3450 4097 3450 3541 
+  Q 3450 3153 3228 2886 
+  Q 3006 2619 2597 2516 
+  z
+  " transform="scale(0.015625)"/>
+         </defs>
+         <use xlink:href="#DejaVuSans-33"/>
+         <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+         <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+        </g>
+       </g>
+      </g>
+      <g id="xtick_8">
+       <g id="line2d_8">
+        <g>
+         <use xlink:href="#m067c08e0d7" x="357.905455" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_8">
+        <!-- 3.5 -->
+        <g transform="translate(349.953892 322.182437) scale(0.1 -0.1)">
+         <use xlink:href="#DejaVuSans-33"/>
+         <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+         <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+        </g>
+       </g>
+      </g>
+      <g id="xtick_9">
+       <g id="line2d_9">
+        <g>
+         <use xlink:href="#m067c08e0d7" x="398.487273" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_9">
+        <!-- 4.0 -->
+        <g transform="translate(390.53571 322.182437) scale(0.1 -0.1)">
+         <defs>
+          <path id="DejaVuSans-34" d="M 2419 4116 
+  L 825 1625 
+  L 2419 1625 
+  L 2419 4116 
+  z
+  M 2253 4666 
+  L 3047 4666 
+  L 3047 1625 
+  L 3713 1625 
+  L 3713 1100 
+  L 3047 1100 
+  L 3047 0 
+  L 2419 0 
+  L 2419 1100 
+  L 313 1100 
+  L 313 1709 
+  L 2253 4666 
+  z
+  " transform="scale(0.015625)"/>
+         </defs>
+         <use xlink:href="#DejaVuSans-34"/>
+         <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+         <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+        </g>
+       </g>
+      </g>
+      <g id="text_10">
+       <!-- x -->
+       <g transform="translate(233.200625 335.860562) scale(0.1 -0.1)">
+        <defs>
+         <path id="DejaVuSans-78" d="M 3513 3500 
+  L 2247 1797 
+  L 3578 0 
+  L 2900 0 
+  L 1881 1375 
+  L 863 0 
+  L 184 0 
+  L 1544 1831 
+  L 300 3500 
+  L 978 3500 
+  L 1906 2253 
+  L 2834 3500 
+  L 3513 3500 
+  z
+  " transform="scale(0.015625)"/>
+        </defs>
+        <use xlink:href="#DejaVuSans-78"/>
+       </g>
+      </g>
+     </g>
+     <g id="matplotlib.axis_2">
+      <g id="ytick_1">
+       <g id="line2d_10">
+        <defs>
+         <path id="m054f990ef5" d="M 0 0 
+  L -3.5 0 
+  " style="stroke: #000000; stroke-width: 0.8"/>
+        </defs>
+        <g>
+         <use xlink:href="#m054f990ef5" x="57.6" y="295.488" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_11">
+        <!-- 0.0 -->
+        <g transform="translate(34.696875 299.287219) scale(0.1 -0.1)">
+         <use xlink:href="#DejaVuSans-30"/>
+         <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+         <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+        </g>
+       </g>
+      </g>
+      <g id="ytick_2">
+       <g id="line2d_11">
+        <g>
+         <use xlink:href="#m054f990ef5" x="57.6" y="265.248" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_12">
+        <!-- 0.5 -->
+        <g transform="translate(34.696875 269.047219) scale(0.1 -0.1)">
+         <use xlink:href="#DejaVuSans-30"/>
+         <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+         <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+        </g>
+       </g>
+      </g>
+      <g id="ytick_3">
+       <g id="line2d_12">
+        <g>
+         <use xlink:href="#m054f990ef5" x="57.6" y="235.008" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_13">
+        <!-- 1.0 -->
+        <g transform="translate(34.696875 238.807219) scale(0.1 -0.1)">
+         <use xlink:href="#DejaVuSans-31"/>
+         <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+         <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+        </g>
+       </g>
+      </g>
+      <g id="ytick_4">
+       <g id="line2d_13">
+        <g>
+         <use xlink:href="#m054f990ef5" x="57.6" y="204.768" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_14">
+        <!-- 1.5 -->
+        <g transform="translate(34.696875 208.567219) scale(0.1 -0.1)">
+         <use xlink:href="#DejaVuSans-31"/>
+         <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+         <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+        </g>
+       </g>
+      </g>
+      <g id="ytick_5">
+       <g id="line2d_14">
+        <g>
+         <use xlink:href="#m054f990ef5" x="57.6" y="174.528" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_15">
+        <!-- 2.0 -->
+        <g transform="translate(34.696875 178.327219) scale(0.1 -0.1)">
+         <use xlink:href="#DejaVuSans-32"/>
+         <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+         <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+        </g>
+       </g>
+      </g>
+      <g id="ytick_6">
+       <g id="line2d_15">
+        <g>
+         <use xlink:href="#m054f990ef5" x="57.6" y="144.288" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_16">
+        <!-- 2.5 -->
+        <g transform="translate(34.696875 148.087219) scale(0.1 -0.1)">
+         <use xlink:href="#DejaVuSans-32"/>
+         <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+         <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+        </g>
+       </g>
+      </g>
+      <g id="ytick_7">
+       <g id="line2d_16">
+        <g>
+         <use xlink:href="#m054f990ef5" x="57.6" y="114.048" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_17">
+        <!-- 3.0 -->
+        <g transform="translate(34.696875 117.847219) scale(0.1 -0.1)">
+         <use xlink:href="#DejaVuSans-33"/>
+         <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+         <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+        </g>
+       </g>
+      </g>
+      <g id="ytick_8">
+       <g id="line2d_17">
+        <g>
+         <use xlink:href="#m054f990ef5" x="57.6" y="83.808" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_18">
+        <!-- 3.5 -->
+        <g transform="translate(34.696875 87.607219) scale(0.1 -0.1)">
+         <use xlink:href="#DejaVuSans-33"/>
+         <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+         <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+        </g>
+       </g>
+      </g>
+      <g id="ytick_9">
+       <g id="line2d_18">
+        <g>
+         <use xlink:href="#m054f990ef5" x="57.6" y="53.568" style="stroke: #000000; stroke-width: 0.8"/>
+        </g>
+       </g>
+       <g id="text_19">
+        <!-- 4.0 -->
+        <g transform="translate(34.696875 57.367219) scale(0.1 -0.1)">
+         <use xlink:href="#DejaVuSans-34"/>
+         <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+         <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+        </g>
+       </g>
+      </g>
+      <g id="text_20">
+       <!-- y -->
+       <g transform="translate(28.617188 177.487375) rotate(-90) scale(0.1 -0.1)">
+        <defs>
+         <path id="DejaVuSans-79" d="M 2059 -325 
+  Q 1816 -950 1584 -1140 
+  Q 1353 -1331 966 -1331 
+  L 506 -1331 
+  L 506 -850 
+  L 844 -850 
+  Q 1081 -850 1212 -737 
+  Q 1344 -625 1503 -206 
+  L 1606 56 
+  L 191 3500 
+  L 800 3500 
+  L 1894 763 
+  L 2988 3500 
+  L 3597 3500 
+  L 2059 -325 
+  z
+  " transform="scale(0.015625)"/>
+        </defs>
+        <use xlink:href="#DejaVuSans-79"/>
+       </g>
+      </g>
+     </g>
+     <g id="patch_3">
+      <path d="M 57.6 307.584 
+  L 57.6 41.472 
+  " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+     </g>
+     <g id="patch_4">
+      <path d="M 414.72 307.584 
+  L 414.72 41.472 
+  " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+     </g>
+     <g id="patch_5">
+      <path d="M 57.6 307.584 
+  L 414.72 307.584 
+  " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+     </g>
+     <g id="patch_6">
+      <path d="M 57.6 41.472 
+  L 414.72 41.472 
+  " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+     </g>
+     <g id="text_21">
+      <!-- This is a scatter -->
+      <g transform="translate(188.745937 35.472) scale(0.12 -0.12)">
+       <defs>
+        <path id="DejaVuSans-54" d="M -19 4666 
+  L 3928 4666 
+  L 3928 4134 
+  L 2272 4134 
+  L 2272 0 
+  L 1638 0 
+  L 1638 4134 
+  L -19 4134 
+  L -19 4666 
+  z
+  " transform="scale(0.015625)"/>
+        <path id="DejaVuSans-68" d="M 3513 2113 
+  L 3513 0 
+  L 2938 0 
+  L 2938 2094 
+  Q 2938 2591 2744 2837 
+  Q 2550 3084 2163 3084 
+  Q 1697 3084 1428 2787 
+  Q 1159 2491 1159 1978 
+  L 1159 0 
+  L 581 0 
+  L 581 4863 
+  L 1159 4863 
+  L 1159 2956 
+  Q 1366 3272 1645 3428 
+  Q 1925 3584 2291 3584 
+  Q 2894 3584 3203 3211 
+  Q 3513 2838 3513 2113 
+  z
+  " transform="scale(0.015625)"/>
+        <path id="DejaVuSans-69" d="M 603 3500 
+  L 1178 3500 
+  L 1178 0 
+  L 603 0 
+  L 603 3500 
+  z
+  M 603 4863 
+  L 1178 4863 
+  L 1178 4134 
+  L 603 4134 
+  L 603 4863 
+  z
+  " transform="scale(0.015625)"/>
+        <path id="DejaVuSans-73" d="M 2834 3397 
+  L 2834 2853 
+  Q 2591 2978 2328 3040 
+  Q 2066 3103 1784 3103 
+  Q 1356 3103 1142 2972 
+  Q 928 2841 928 2578 
+  Q 928 2378 1081 2264 
+  Q 1234 2150 1697 2047 
+  L 1894 2003 
+  Q 2506 1872 2764 1633 
+  Q 3022 1394 3022 966 
+  Q 3022 478 2636 193 
+  Q 2250 -91 1575 -91 
+  Q 1294 -91 989 -36 
+  Q 684 19 347 128 
+  L 347 722 
+  Q 666 556 975 473 
+  Q 1284 391 1588 391 
+  Q 1994 391 2212 530 
+  Q 2431 669 2431 922 
+  Q 2431 1156 2273 1281 
+  Q 2116 1406 1581 1522 
+  L 1381 1569 
+  Q 847 1681 609 1914 
+  Q 372 2147 372 2553 
+  Q 372 3047 722 3315 
+  Q 1072 3584 1716 3584 
+  Q 2034 3584 2315 3537 
+  Q 2597 3491 2834 3397 
+  z
+  " transform="scale(0.015625)"/>
+        <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-61" d="M 2194 1759 
+  Q 1497 1759 1228 1600 
+  Q 959 1441 959 1056 
+  Q 959 750 1161 570 
+  Q 1363 391 1709 391 
+  Q 2188 391 2477 730 
+  Q 2766 1069 2766 1631 
+  L 2766 1759 
+  L 2194 1759 
+  z
+  M 3341 1997 
+  L 3341 0 
+  L 2766 0 
+  L 2766 531 
+  Q 2569 213 2275 61 
+  Q 1981 -91 1556 -91 
+  Q 1019 -91 701 211 
+  Q 384 513 384 1019 
+  Q 384 1609 779 1909 
+  Q 1175 2209 1959 2209 
+  L 2766 2209 
+  L 2766 2266 
+  Q 2766 2663 2505 2880 
+  Q 2244 3097 1772 3097 
+  Q 1472 3097 1187 3025 
+  Q 903 2953 641 2809 
+  L 641 3341 
+  Q 956 3463 1253 3523 
+  Q 1550 3584 1831 3584 
+  Q 2591 3584 2966 3190 
+  Q 3341 2797 3341 1997 
+  z
+  " transform="scale(0.015625)"/>
+        <path id="DejaVuSans-63" d="M 3122 3366 
+  L 3122 2828 
+  Q 2878 2963 2633 3030 
+  Q 2388 3097 2138 3097 
+  Q 1578 3097 1268 2742 
+  Q 959 2388 959 1747 
+  Q 959 1106 1268 751 
+  Q 1578 397 2138 397 
+  Q 2388 397 2633 464 
+  Q 2878 531 3122 666 
+  L 3122 134 
+  Q 2881 22 2623 -34 
+  Q 2366 -91 2075 -91 
+  Q 1284 -91 818 406 
+  Q 353 903 353 1747 
+  Q 353 2603 823 3093 
+  Q 1294 3584 2113 3584 
+  Q 2378 3584 2631 3529 
+  Q 2884 3475 3122 3366 
+  z
+  " transform="scale(0.015625)"/>
+        <path id="DejaVuSans-74" d="M 1172 4494 
+  L 1172 3500 
+  L 2356 3500 
+  L 2356 3053 
+  L 1172 3053 
+  L 1172 1153 
+  Q 1172 725 1289 603 
+  Q 1406 481 1766 481 
+  L 2356 481 
+  L 2356 0 
+  L 1766 0 
+  Q 1100 0 847 248 
+  Q 594 497 594 1153 
+  L 594 3053 
+  L 172 3053 
+  L 172 3500 
+  L 594 3500 
+  L 594 4494 
+  L 1172 4494 
+  z
+  " transform="scale(0.015625)"/>
+        <path id="DejaVuSans-65" d="M 3597 1894 
+  L 3597 1613 
+  L 953 1613 
+  Q 991 1019 1311 708 
+  Q 1631 397 2203 397 
+  Q 2534 397 2845 478 
+  Q 3156 559 3463 722 
+  L 3463 178 
+  Q 3153 47 2828 -22 
+  Q 2503 -91 2169 -91 
+  Q 1331 -91 842 396 
+  Q 353 884 353 1716 
+  Q 353 2575 817 3079 
+  Q 1281 3584 2069 3584 
+  Q 2775 3584 3186 3129 
+  Q 3597 2675 3597 1894 
+  z
+  M 3022 2063 
+  Q 3016 2534 2758 2815 
+  Q 2500 3097 2075 3097 
+  Q 1594 3097 1305 2825 
+  Q 1016 2553 972 2059 
+  L 3022 2063 
+  z
+  " transform="scale(0.015625)"/>
+        <path id="DejaVuSans-72" d="M 2631 2963 
+  Q 2534 3019 2420 3045 
+  Q 2306 3072 2169 3072 
+  Q 1681 3072 1420 2755 
+  Q 1159 2438 1159 1844 
+  L 1159 0 
+  L 581 0 
+  L 581 3500 
+  L 1159 3500 
+  L 1159 2956 
+  Q 1341 3275 1631 3429 
+  Q 1922 3584 2338 3584 
+  Q 2397 3584 2469 3576 
+  Q 2541 3569 2628 3553 
+  L 2631 2963 
+  z
+  " transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-54"/>
+       <use xlink:href="#DejaVuSans-68" x="61.083984"/>
+       <use xlink:href="#DejaVuSans-69" x="124.462891"/>
+       <use xlink:href="#DejaVuSans-73" x="152.246094"/>
+       <use xlink:href="#DejaVuSans-20" x="204.345703"/>
+       <use xlink:href="#DejaVuSans-69" x="236.132812"/>
+       <use xlink:href="#DejaVuSans-73" x="263.916016"/>
+       <use xlink:href="#DejaVuSans-20" x="316.015625"/>
+       <use xlink:href="#DejaVuSans-61" x="347.802734"/>
+       <use xlink:href="#DejaVuSans-20" x="409.082031"/>
+       <use xlink:href="#DejaVuSans-73" x="440.869141"/>
+       <use xlink:href="#DejaVuSans-63" x="492.96875"/>
+       <use xlink:href="#DejaVuSans-61" x="547.949219"/>
+       <use xlink:href="#DejaVuSans-74" x="609.228516"/>
+       <use xlink:href="#DejaVuSans-74" x="648.4375"/>
+       <use xlink:href="#DejaVuSans-65" x="687.646484"/>
+       <use xlink:href="#DejaVuSans-72" x="749.169922"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <defs>
+    <clipPath id="pb8778e6b03">
+     <rect x="57.6" y="41.472" width="357.12" height="266.112"/>
+    </clipPath>
+   </defs>
+  </svg>
+  
+  '''
+# ---

--- a/example/test_matplotlib.py
+++ b/example/test_matplotlib.py
@@ -1,0 +1,95 @@
+import io
+import pathlib
+from typing import Any
+
+import matplotlib as mpl  # type: ignore
+import matplotlib.pyplot as plt  # type: ignore
+import numpy as np
+
+BASE_PATH = pathlib.Path("data/examples/graphs")
+BASE_PATH.mkdir(parents=True, exist_ok=True)
+SnapShot = Any
+
+
+def test_matplotlib(snapshot: SnapShot) -> None:
+    """Test matplotlib svg output."""
+    snapshot.snapshot_dir = "snapshots/matplotlib"
+    mpl.rcParams["svg.hashsalt"] = "test"
+    fp = io.StringIO()
+
+    _, ax = plt.subplots()
+    x = np.linspace(0, 20, 100)
+    y = np.sin(x)
+    ax.plot(x, y)
+    ax.set_title("This is a plot")
+    ax.set_xlabel("x")
+    ax.set_ylabel("sin(x)")
+    # plt.show()
+
+    metadata = {"Date": None}  # Remove date from metadata for reproducibility
+    plt.savefig(fp, format="svg", metadata=metadata)
+    plt.savefig(BASE_PATH / "test1.svg", metadata=metadata)
+    assert fp.getvalue() == snapshot
+
+
+def test_matplotlib_hist(snapshot: SnapShot) -> None:
+    """Test matplotlib histogram svg output."""
+    snapshot.snapshot_dir = "snapshots/matplotlib"
+    mpl.rcParams["svg.hashsalt"] = "test"
+    fp = io.StringIO()
+
+    _, ax = plt.subplots()
+    np.random.seed(0)
+    x = np.random.normal(size=1000)
+    ax.hist(x, bins=20)
+    ax.set_title("This is a histogram")
+    ax.set_xlabel("x")
+    ax.set_ylabel("y (random)")
+    # plt.show()
+
+    metadata = {"Date": None}  # Remove date from metadata for reproducibility
+    plt.savefig(fp, format="svg", metadata=metadata)
+    plt.savefig(BASE_PATH / "test2.svg", metadata=metadata)
+    assert fp.getvalue() == snapshot
+
+
+def test_matplotlib_bar(snapshot: SnapShot) -> None:
+    """Test matplotlib bar svg output."""
+    snapshot.snapshot_dir = "snapshots/matplotlib"
+    mpl.rcParams["svg.hashsalt"] = "test"
+    fp = io.StringIO()
+
+    _, ax = plt.subplots()
+    x = np.arange(5)
+    y = np.arange(5)
+    ax.bar(x, y)
+    ax.set_title("This is a bar")
+    ax.set_xlabel("x")
+    ax.set_ylabel("y")
+    # plt.show()
+
+    metadata = {"Date": None}  # Remove date from metadata for reproducibility
+    plt.savefig(fp, format="svg", metadata=metadata)
+    plt.savefig(BASE_PATH / "test3.svg", metadata=metadata)
+    assert fp.getvalue() == snapshot
+
+
+def test_matplotlib_scatter(snapshot: SnapShot) -> None:
+    """Test matplotlib scatter svg output."""
+    snapshot.snapshot_dir = "snapshots/matplotlib"
+    mpl.rcParams["svg.hashsalt"] = "test"
+    fp = io.StringIO()
+
+    _, ax = plt.subplots()
+    x = np.arange(5)
+    y = np.arange(5)
+    ax.scatter(x, y)
+    ax.set_title("This is a scatter")
+    ax.set_xlabel("x")
+    ax.set_ylabel("y")
+    # plt.show()
+
+    metadata = {"Date": None}  # Remove date from metadata for reproducibility
+    plt.savefig(fp, format="svg", metadata=metadata)
+    plt.savefig(BASE_PATH / "test4.svg", metadata=metadata)
+    assert fp.getvalue() == snapshot

--- a/poetry.lock
+++ b/poetry.lock
@@ -335,6 +335,17 @@ files = [
 ]
 
 [[package]]
+name = "colored"
+version = "1.4.4"
+description = "Simple library for color and formatting to terminal"
+category = "dev"
+optional = false
+python-versions = "*"
+files = [
+    {file = "colored-1.4.4.tar.gz", hash = "sha256:04ff4d4dd514274fe3b99a21bb52fb96f2688c01e93fba7bef37221e7cb56ce0"},
+]
+
+[[package]]
 name = "comm"
 version = "0.1.2"
 description = "Jupyter Python Comm implementation, for usage in ipykernel, xeus-python etc."
@@ -2653,6 +2664,22 @@ pure-eval = "*"
 tests = ["cython", "littleutils", "pygments", "pytest", "typeguard"]
 
 [[package]]
+name = "syrupy"
+version = "3.0.6"
+description = "Pytest Snapshot Test Utility"
+category = "dev"
+optional = false
+python-versions = ">=3.7,<4"
+files = [
+    {file = "syrupy-3.0.6-py3-none-any.whl", hash = "sha256:9c18e22264026b34239bcc87ab7cc8d893eb17236ea7dae634217ea4f22a848d"},
+    {file = "syrupy-3.0.6.tar.gz", hash = "sha256:583aa5ca691305c27902c3e29a1ce9da50ff9ab5f184c54b1dc124a16e4a6cf4"},
+]
+
+[package.dependencies]
+colored = ">=1.3.92,<2.0.0"
+pytest = ">=5.1.0,<8.0.0"
+
+[[package]]
 name = "terminado"
 version = "0.17.1"
 description = "Tornado websocket backend for the Xterm.js Javascript terminal emulator library."
@@ -2931,4 +2958,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "a93170607c24cb416b64dbe86745433962e4b432a0676b6eb3011730783640a6"
+content-hash = "27f5c3d9116b2d49b6b52e1d1fda16c617a44c2d0aa4769a086d9ac0b573b8be"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ pyupgrade = "*"
 pytest-cov = "*"
 flake8 = "*"
 mypy = "*"
+syrupy = "^3.0.6"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Use SVG instead of binary images for lighter tests.
Use syrupy to take advantage of snapshot tests.

Close: https://github.com/kitsuyui/ml-playground/issues/15