### PR TITLE
Fix poethepoet usage in GitHub Actions

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -34,12 +34,10 @@ jobs:
 
       - if: ${{ steps.cache-python.outputs.cache-hit != 'true' }}
         name: Install dependencies
-        run: |
-          poetry install
-          poetry self add 'poethepoet[poetry_plugin]'
+        run: poetry install
 
       - name: Lint
-        run: poetry poe check
+        run: poetry run poe check
 
       - name: Check Python version
         run: |
@@ -51,7 +49,7 @@ jobs:
           fi
 
       - name: Test
-        run: poetry poe coverage-xml
+        run: poetry run poe coverage-xml
 
       - name: Upload coverage report to Codecov
         if: matrix.python == '3.11'


### PR DESCRIPTION
poethepoet is a task runner and a plugin for poetry to manage dependencies.
By installing it as a plugin, you can write `poetry run poe xxx` instead of `poetry poe xxx`.
I used it as a plugin in GitHub Actions, but it doesn't work well with cache, so I'll write `poetry run poe xxx` instead.
