### PR TITLE
Speed up tests by parallelization

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -827,6 +827,21 @@ files = [
 test = ["pytest (>=6)"]
 
 [[package]]
+name = "execnet"
+version = "1.9.0"
+description = "execnet: rapid multi-Python deployment"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+files = [
+    {file = "execnet-1.9.0-py2.py3-none-any.whl", hash = "sha256:a295f7cc774947aac58dde7fdc85f4aa00c42adf5d8f5468fc630c1acf30a142"},
+    {file = "execnet-1.9.0.tar.gz", hash = "sha256:8f694f3ba9cc92cab508b152dcfe322153975c29bda272e2fd7f3f00f36e47c5"},
+]
+
+[package.extras]
+testing = ["pre-commit"]
+
+[[package]]
 name = "executing"
 version = "1.2.0"
 description = "Get the currently executing AST node of a frame, and other information"
@@ -2928,6 +2943,27 @@ pytest = ">=4.6"
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtualenv"]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.1.0"
+description = "pytest xdist plugin for distributed testing, most importantly across multiple CPUs"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pytest-xdist-3.1.0.tar.gz", hash = "sha256:40fdb8f3544921c5dfcd486ac080ce22870e71d82ced6d2e78fa97c2addd480c"},
+    {file = "pytest_xdist-3.1.0-py3-none-any.whl", hash = "sha256:70a76f191d8a1d2d6be69fc440cdf85f3e4c03c08b520fd5dc5d338d6cf07d89"},
+]
+
+[package.dependencies]
+execnet = ">=1.1"
+pytest = ">=6.2.0"
+
+[package.extras]
+psutil = ["psutil (>=3.0)"]
+setproctitle = ["setproctitle"]
+testing = ["filelock"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
@@ -4112,4 +4148,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "48890b814f607eba0285e8e76f38cc8101cfe64f7628f5d018d8a6cd4e75ef7f"
+content-hash = "7f409b1d32d2b89e10b42bfe7358f68767f101daf485e95e0c1b9f62edf6075b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,8 @@ flake8 = "*"
 mypy = "*"
 syrupy = "*"
 poethepoet = "*"
-nbmake = "^1.3.5"
+nbmake = "*"
+pytest-xdist = "*"
 
 [build-system]
 requires = ["poetry-core"]
@@ -66,7 +67,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poe.tasks]
 test = [
     { cmd = "pytest" },
-    { cmd = "pytest --nbmake notebooks" },
+    { cmd = "pytest --nbmake notebooks -n auto" },
 ]
 coverage-xml = "pytest --cov=example example --doctest-modules --cov-report=xml"
 format = [


### PR DESCRIPTION
Install pytest-xdist.
Parallelize the more time-consuming notebooks tests
