### PR TITLE
Add test for torch.device

### DIFF
--- a/example/torch/test_device.py
+++ b/example/torch/test_device.py
@@ -1,0 +1,72 @@
+# ja: device の互換性のテスト
+# en: test device compatibility
+
+import sys
+from typing import Iterator
+
+import pytest
+import torch
+from torch import Tensor
+
+
+def test_backends() -> None:
+    assert not torch.backends.cudnn.is_available()
+    assert not torch.backends.mkl.is_available()
+    assert not torch.backends.mkldnn.is_available()
+    assert not torch.backends.openmp.is_available()
+
+    # darwin
+    if sys.platform == "darwin":
+        assert torch.backends.mps.is_available()
+
+
+def get_devices() -> Iterator[torch.device]:
+    # get all devices
+    if torch.cuda.is_available():
+        for i in range(torch.cuda.device_count()):
+            yield torch.device(f"cuda:{i}")
+    elif torch.backends.mps.is_available():
+        yield torch.device("mps")
+    yield torch.device("cpu")
+
+
+def test_device_equality() -> None:
+    devices = list(get_devices())
+    device1 = devices[0]
+    device2 = devices[-1]
+    assert device1 != device2
+
+
+def test_device_instance_equality() -> None:
+    devices1 = list(get_devices())
+    devices2 = list(get_devices())
+    # check that the devices are the same in both lists)
+    for device1, device2 in zip(devices1, devices2):
+        assert device1 == device2, "device1 != device2"
+        assert device1 is not device2, "device1 is device2"
+
+
+def test_device_compatibility() -> None:
+    devices = list(get_devices())
+    device1 = devices[0]
+    device2 = devices[-1]
+    tensor1 = Tensor([1, 2, 3]).to(device1)
+    tensor2 = Tensor([1, 2, 3]).to(device2)
+    with pytest.raises(RuntimeError) as e:
+        tensor1 += tensor2
+    assert "Expected all tensors to be on the same device" in str(e.value)
+
+    with pytest.raises(RuntimeError) as e:
+        tensor2 += tensor1
+    assert "Expected all tensors to be on the same device" in str(e.value)
+
+
+def test_default_device() -> None:
+    devices = list(get_devices())
+    device1 = devices[0]
+    tensor1 = Tensor([1, 2, 3]).to(device1)
+    tensor2 = Tensor([1, 2, 3])  # default device
+
+    with pytest.raises(RuntimeError) as e:
+        tensor1 += tensor2
+    assert "Expected all tensors to be on the same device" in str(e.value)

--- a/example/torch/test_device.py
+++ b/example/torch/test_device.py
@@ -10,63 +10,72 @@ from torch import Tensor
 
 
 def test_backends() -> None:
-    assert not torch.backends.cudnn.is_available()
-    assert not torch.backends.mkl.is_available()
-    assert not torch.backends.mkldnn.is_available()
-    assert not torch.backends.openmp.is_available()
-
-    # darwin
+    # TODO: other platforms
     if sys.platform == "darwin":
+        assert not torch.backends.cudnn.is_available()
+        assert not torch.backends.mkl.is_available()
+        assert not torch.backends.mkldnn.is_available()
+        assert not torch.backends.openmp.is_available()
         assert torch.backends.mps.is_available()
 
 
 def get_devices() -> Iterator[torch.device]:
-    # get all devices
-    if torch.cuda.is_available():
-        for i in range(torch.cuda.device_count()):
-            yield torch.device(f"cuda:{i}")
-    elif torch.backends.mps.is_available():
-        yield torch.device("mps")
-    yield torch.device("cpu")
+    # TODO: other platforms
+    if sys.platform == "darwin":
+        # get all devices
+        if torch.cuda.is_available():
+            for i in range(torch.cuda.device_count()):
+                yield torch.device(f"cuda:{i}")
+        elif torch.backends.mps.is_available():
+            yield torch.device("mps")
+        yield torch.device("cpu")
 
 
 def test_device_equality() -> None:
-    devices = list(get_devices())
-    device1 = devices[0]
-    device2 = devices[-1]
-    assert device1 != device2
+    # TODO: other platforms
+    if sys.platform == "darwin":
+        devices = list(get_devices())
+        device1 = devices[0]
+        device2 = devices[1]
+        assert device1 != device2
 
 
 def test_device_instance_equality() -> None:
-    devices1 = list(get_devices())
-    devices2 = list(get_devices())
-    # check that the devices are the same in both lists)
-    for device1, device2 in zip(devices1, devices2):
-        assert device1 == device2, "device1 != device2"
-        assert device1 is not device2, "device1 is device2"
+    # TODO: other platforms
+    if sys.platform == "darwin":
+        devices1 = list(get_devices())
+        devices2 = list(get_devices())
+        # check that the devices are the same in both lists)
+        for device1, device2 in zip(devices1, devices2):
+            assert device1 == device2, "device1 != device2"
+            assert device1 is not device2, "device1 is device2"
 
 
 def test_device_compatibility() -> None:
-    devices = list(get_devices())
-    device1 = devices[0]
-    device2 = devices[-1]
-    tensor1 = Tensor([1, 2, 3]).to(device1)
-    tensor2 = Tensor([1, 2, 3]).to(device2)
-    with pytest.raises(RuntimeError) as e:
-        tensor1 += tensor2
-    assert "Expected all tensors to be on the same device" in str(e.value)
+    # TODO: other platforms
+    if sys.platform == "darwin":
+        devices = list(get_devices())
+        device1 = devices[0]
+        device2 = devices[1]
+        tensor1 = Tensor([1, 2, 3]).to(device1)
+        tensor2 = Tensor([1, 2, 3]).to(device2)
+        with pytest.raises(RuntimeError) as e:
+            tensor1 += tensor2
+        assert "Expected all tensors to be on the same device" in str(e.value)
 
-    with pytest.raises(RuntimeError) as e:
-        tensor2 += tensor1
-    assert "Expected all tensors to be on the same device" in str(e.value)
+        with pytest.raises(RuntimeError) as e:
+            tensor2 += tensor1
+        assert "Expected all tensors to be on the same device" in str(e.value)
 
 
 def test_default_device() -> None:
-    devices = list(get_devices())
-    device1 = devices[0]
-    tensor1 = Tensor([1, 2, 3]).to(device1)
-    tensor2 = Tensor([1, 2, 3])  # default device
+    # TODO: other platforms
+    if sys.platform == "darwin":
+        devices = list(get_devices())
+        device1 = devices[0]
+        tensor1 = Tensor([1, 2, 3]).to(device1)
+        tensor2 = Tensor([1, 2, 3])  # default device
 
-    with pytest.raises(RuntimeError) as e:
-        tensor1 += tensor2
-    assert "Expected all tensors to be on the same device" in str(e.value)
+        with pytest.raises(RuntimeError) as e:
+            tensor1 += tensor2
+        assert "Expected all tensors to be on the same device" in str(e.value)


### PR DESCRIPTION
There are several types of torch.device, such as cuda, cpu, and mps.
If the types do not match, the operation between tensors cannot be performed.
Add examples for these types.
