### PR TITLE
Represent LRScheduler as Union

### DIFF
--- a/example/torch/scheduler.py
+++ b/example/torch/scheduler.py
@@ -1,0 +1,19 @@
+from typing import Union
+
+import torch
+
+# treat all scheduler classes as a single type.
+LRScheduler = Union[
+    torch.optim.lr_scheduler.ConstantLR,
+    torch.optim.lr_scheduler.CosineAnnealingLR,
+    torch.optim.lr_scheduler.CyclicLR,
+    torch.optim.lr_scheduler.ExponentialLR,
+    torch.optim.lr_scheduler.LambdaLR,
+    torch.optim.lr_scheduler.LinearLR,
+    torch.optim.lr_scheduler.MultiStepLR,
+    torch.optim.lr_scheduler.MultiplicativeLR,
+    torch.optim.lr_scheduler.OneCycleLR,
+    torch.optim.lr_scheduler.PolynomialLR,
+    torch.optim.lr_scheduler.SequentialLR,
+    torch.optim.lr_scheduler.StepLR,
+]

--- a/example/torch/test_scheduler.py
+++ b/example/torch/test_scheduler.py
@@ -1,0 +1,12 @@
+import pytest
+import torch
+
+from example.torch.scheduler import LRScheduler
+
+
+def test_scheduler() -> None:
+    optimizer = torch.optim.SGD([torch.zeros(1)], lr=0.1)
+    scheduler: LRScheduler = torch.optim.lr_scheduler.ConstantLR(
+        optimizer, 0.1
+    )
+    assert pytest.approx(scheduler.get_last_lr()) == [0.01]


### PR DESCRIPTION
There are many types of `LRScheduler` subclasses.
However, there are situations where it is not necessary to distinguish them clearly.
For example, when comparing multiple schedulers, it would be convenient to represent them as a Union
