### PR TITLE
Test that torch.jit.script is supported

### DIFF
--- a/example/torch/test_categorical_embedding.py
+++ b/example/torch/test_categorical_embedding.py
@@ -37,3 +37,24 @@ def test_categorical_embedding() -> None:
     # trainability
     y.sum().backward()
     assert ce.scale_embedding.embedding.weight.grad is not None
+
+
+def test_torch_jit_ready() -> None:
+    """Test that the module is torch.jit.script() ready."""
+    embedding_dim = 4
+    ce = CategoricalEmbedding(
+        num_categories=6,
+        embedding_dim=embedding_dim,
+        dropout=0.1,
+    )
+    ce = torch.jit.script(ce)
+    x = torch.tensor(
+        [1, 2, 3],
+    )
+    assert x.shape == (3,)
+    assert x.dtype == torch.int64
+    y = ce(x)
+    assert y.shape == (3, 4)
+    assert y.dtype == torch.float32
+    assert (*x.shape, embedding_dim) == y.shape
+    assert ce.code is not None

--- a/example/torch/test_numerical_embedding.py
+++ b/example/torch/test_numerical_embedding.py
@@ -36,3 +36,24 @@ def test_numerical_embedding() -> None:
     # trainability
     y.sum().backward()
     assert ne.weights.grad is not None
+
+
+def test_torch_jit_ready() -> None:
+    """Test that the module is torch.jit.script() ready."""
+    embedding_dim = 4
+    ne = NumericalEmbedding(
+        embedding_dim=embedding_dim,
+        num_values=6,
+        dropout=0.1,
+    )
+    ne = torch.jit.script(ne)
+    x = torch.tensor(
+        [0.1, 0.2, 0.3, 0.4, 0.5, 0.1],
+    )
+    assert x.shape == (6,)
+    assert x.dtype == torch.float32
+    y = ne(x)
+    assert y.shape == (6, 4)
+    assert y.dtype == torch.float32
+    assert (*x.shape, embedding_dim) == y.shape
+    assert ne.code is not None

--- a/example/torch/test_positional_encoding.py
+++ b/example/torch/test_positional_encoding.py
@@ -52,3 +52,21 @@ PositionalEncoding2(
 
     # the original implementation is faster because it is simpler (it does not use Sequential module)
     assert t0 < t1
+
+
+def test_torch_jit_ready() -> None:
+    """Test that the module is torch.jit.script() ready."""
+    pe = PositionalEncoding(d_model=4, dropout=0.0)
+    pe = torch.jit.script(pe)
+    x = torch.Tensor(
+        [1.0, 2.0, 3.0, 4.0],
+    )
+    y = pe(x)
+    assert y.shape == (4, 1, 4)
+    assert pe.code is not None
+
+    pe2 = PositionalEncoding2(d_model=4, dropout=0.0)
+    pe2 = torch.jit.script(pe2)
+    y2 = pe2(x)
+    assert y2.shape == (4, 1, 4)
+    assert pe2.code is not None

--- a/example/torch/test_scale_embedding.py
+++ b/example/torch/test_scale_embedding.py
@@ -27,3 +27,22 @@ def test_scale_embedding() -> None:
     # ScaleEmbedding2 uses register_buffer, but it is slower than ScaleEmbedding
     # register_buffer suits for more large constant tensors
     assert t0 < t1
+
+
+def test_torch_jit_ready() -> None:
+    """Test that the module is torch.jit.script() ready."""
+    num_embeddings = 100
+    embedding_dim = 100
+    x = torch.randint(num_embeddings, (200,))
+
+    se = ScaleEmbedding(num_embeddings, embedding_dim)
+    se = torch.jit.script(se)
+    y = se(x)
+    assert y.shape == (200, 100)
+    assert se.code is not None
+
+    se2 = ScaleEmbedding2(num_embeddings, embedding_dim)
+    se2 = torch.jit.script(se2)
+    y2 = se2(x)
+    assert y2.shape == (200, 100)
+    assert se2.code is not None

--- a/example/torch/test_token_embedding.py
+++ b/example/torch/test_token_embedding.py
@@ -37,3 +37,24 @@ def test_token_embedding() -> None:
     # trainability
     y.sum().backward()
     assert te.scale_embedding.embedding.weight.grad is not None
+
+
+def test_torch_jit_ready() -> None:
+    """Test that the module is torch.jit.script() ready."""
+    embedding_dim = 4
+    te = TokenEmbedding(
+        num_vocab=6,
+        embedding_dim=embedding_dim,
+        dropout=0.1,
+    )
+    te = torch.jit.script(te)
+    x = torch.tensor(
+        [1, 2, 3],
+    )
+    assert x.shape == (3,)
+    assert x.dtype == torch.int64
+    y = te(x)
+    assert y.shape == (3, 4)
+    assert y.dtype == torch.float32
+    assert (*x.shape, embedding_dim) == y.shape
+    assert te.code is not None


### PR DESCRIPTION
Test that torch.jit.script can convert torch.nn.Module to TorchScript.
TorchScript is executed on the C++ backend and can improve performance.
Also, by converting to TorchScript, it also checks that the module is implemented according to pytorch's conventions.
