### PR TITLE
lcm_cat

### DIFF
--- a/example/torch/lcm_cat.py
+++ b/example/torch/lcm_cat.py
@@ -1,0 +1,38 @@
+from typing import List
+
+import torch
+from torch import Tensor
+
+
+def lcm_cat(tensors: List[Tensor], batch_first: bool = False) -> Tensor:
+    """lcm_cat
+
+    Concatenate tensors after expanding the sequence length to the
+    least common multiple of the sequence lengths in the batch.
+    """
+    if batch_first:
+        seq_dim = 1
+    else:
+        seq_dim = 0
+
+    tensors = tensors[:]
+
+    # LCM (Least Common Multiple) of sequence lengths
+    lcm_seq_size = torch.tensor(1)
+    for t in tensors:
+        t_seq_size = torch.tensor(t.shape[seq_dim])
+        torch.lcm(lcm_seq_size, t_seq_size, out=lcm_seq_size)
+
+    # Repeat tensors to match the LCM
+    for i, t in enumerate(tensors):
+        t = t.flatten(start_dim=2).unsqueeze_(-1)
+        seq_size = t.shape[seq_dim]
+        repeat_times = lcm_seq_size // seq_size
+        if batch_first:
+            t = t.repeat(1, repeat_times, 1, 1)
+        else:
+            t = t.repeat(repeat_times, 1, 1, 1)
+        tensors[i] = t.flatten(start_dim=2)
+
+    # Concatenate
+    return torch.cat(tensors, dim=-1)

--- a/example/torch/test_lcm_cat.py
+++ b/example/torch/test_lcm_cat.py
@@ -1,0 +1,76 @@
+import torch
+
+from example.torch.lcm_cat import lcm_cat
+
+
+def test_lcm_cat_batch_first_false() -> None:
+    asis = lcm_cat(
+        [
+            torch.full((2, 3, 2, 3), 8),
+            torch.full((1, 3, 3, 1), 9),
+        ]
+    )
+    tobe = torch.tensor(
+        [
+            [
+                [8, 8, 8, 8, 8, 8, 9, 9, 9],
+                [8, 8, 8, 8, 8, 8, 9, 9, 9],
+                [8, 8, 8, 8, 8, 8, 9, 9, 9],
+            ],
+            [
+                [8, 8, 8, 8, 8, 8, 9, 9, 9],
+                [8, 8, 8, 8, 8, 8, 9, 9, 9],
+                [8, 8, 8, 8, 8, 8, 9, 9, 9],
+            ],
+        ]
+    )
+    assert torch.all(asis == tobe)
+    assert asis.shape == tobe.shape == (2, 3, 9)
+
+
+def test_lcm_cat_batch_first_true() -> None:
+    asis = lcm_cat(
+        [
+            torch.full((3, 2, 2, 3), 8),
+            torch.full((3, 1, 3, 1), 9),
+        ],
+        batch_first=True,
+    )
+    tobe = torch.tensor(
+        [
+            [
+                [8, 8, 8, 8, 8, 8, 9, 9, 9],
+                [8, 8, 8, 8, 8, 8, 9, 9, 9],
+            ],
+            [
+                [8, 8, 8, 8, 8, 8, 9, 9, 9],
+                [8, 8, 8, 8, 8, 8, 9, 9, 9],
+            ],
+            [
+                [8, 8, 8, 8, 8, 8, 9, 9, 9],
+                [8, 8, 8, 8, 8, 8, 9, 9, 9],
+            ],
+        ]
+    )
+    assert torch.all(asis == tobe)
+    assert asis.shape == tobe.shape == (3, 2, 9)
+
+
+def test_lcm_cat_torch_jit_ready() -> None:
+    lcm_cat_jit = torch.jit.script(lcm_cat)
+    asis = lcm_cat_jit(
+        [
+            torch.full((2, 3, 2, 3), 8),
+            torch.full((1, 3, 3, 1), 9),
+        ]
+    )
+    assert asis.shape == (2, 3, 9)
+
+    asis = lcm_cat_jit(
+        [
+            torch.full((3, 2, 2, 3), 8),
+            torch.full((3, 1, 3, 1), 9),
+        ],
+        batch_first=True,
+    )
+    assert asis.shape == (3, 2, 9)


### PR DESCRIPTION
`lcm_cat` is an operation that concatenates multiple tensors.
Normally, `torch.cat` requires that the number of dimensions of the tensors to be concatenated is the same.
lcm_cat can concatenate tensors with different numbers of dimensions.
The least common multiple of the dimensions of the tensors to be concatenated is calculated, and the tensors are expanded to match it before concatenation.

```python
asis = lcm_cat(
    [
        torch.full((2, 3, 2, 3), 8),
        torch.full((1, 3, 3, 1), 9),
    ]
)
tobe = torch.tensor(
    [
        [
            [8, 8, 8, 8, 8, 8, 9, 9, 9],
            [8, 8, 8, 8, 8, 8, 9, 9, 9],
            [8, 8, 8, 8, 8, 8, 9, 9, 9],
        ],
        [
            [8, 8, 8, 8, 8, 8, 9, 9, 9],
            [8, 8, 8, 8, 8, 8, 9, 9, 9],
            [8, 8, 8, 8, 8, 8, 9, 9, 9],
        ],
    ]
)
assert torch.all(asis == tobe)
assert asis.shape == tobe.shape == (2, 3, 9)
```
