### PR TITLE
Workaround for poetry and debugpy compatibility problem

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -32,6 +32,13 @@ jobs:
             ${{ runner.os }}-build-${{ matrix.python }}-
             ${{ runner.os }}-
 
+      - name: Workaround
+        # Remove this step when bug is fixed
+        # https://github.com/kitsuyui/ml-playground/issues/83
+        if: matrix.python == '3.11'
+        run: |
+          poetry config installer.modern-installation false
+
       - if: ${{ steps.cache-python.outputs.cache-hit != 'true' }}
         name: Install dependencies
         run: |


### PR DESCRIPTION
A compatibility problem with poetry v1.4.1 and debugpy has occurred.
In my opinion, the problem occurs because the hash value locked by poetry is different from the hash value locked by debugpy when verdoring pydevd in debugpy.
There are no other problems with many other vendoring packages, so it seems that the problem is with debugpy?
However, it doesn't seem to be resolved soon, so for now, change the poetry configuration as a workaround.
