### PR TITLE
Remove duplicated event in GitHub Workflow

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -1,6 +1,5 @@
 name: Lint and Test Python
 on:
-  - push
   - pull_request
 
 jobs:

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,6 +1,5 @@
 name: Spellcheck
 on:
-  - push
   - pull_request
 permissions:
   contents: read


### PR DESCRIPTION
- push events are already included in pull_request event type `synchronize`
