### PR TITLE
Avoid RuntimeError: MPS backend out of memory

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -54,10 +54,16 @@ jobs:
           fi
 
       - name: Test
-        run: poetry run poe test
+        run: |
+          export PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.0
+          export PYTORCH_ENABLE_MPS_FALLBACK=1
+          poetry run poe test
 
       - name: Coverage
-        run: poetry run poe coverage-xml
+        run: |
+          export PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.0
+          export PYTORCH_ENABLE_MPS_FALLBACK=1
+          poetry run poe coverage-xml
 
       - name: Upload coverage report to Codecov
         if: matrix.python == '3.11'


### PR DESCRIPTION
- Try PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.0 to avoid RuntimeError: MPS backend out of memory
