### PR TITLE
Remove the skipping of the install step when using the cache

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -48,8 +48,7 @@ jobs:
       - name: Set up poetry
         uses: abatilo/actions-poetry@v2
 
-      - if: ${{ steps.cache-python.outputs.cache-hit != 'true' }}
-        name: Install dependencies
+      - name: Install dependencies
         run: poetry install
 
       - name: Lint


### PR DESCRIPTION
Using cache may break the poethepoet command
