### PR TITLE
github actions python version

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -48,6 +48,10 @@ jobs:
             ${{ runner.os }}-build-${{ matrix.python }}-${{ hashFiles('**/poetry.lock') }}
             ${{ runner.os }}-build-${{ matrix.python }}-
 
+      # This step is needed to make sure that the correct Python version is used
+      - run: |
+          poetry env use python${{ matrix.python }}
+
       - name: Install dependencies
         run: poetry install
 

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -31,7 +31,7 @@ jobs:
           python-version: "${{ matrix.python }}"
 
       - name: Set up poetry
-        uses: abatilo/actions-poetry@v2
+        uses: abatilo/actions-poetry@v3
 
       - name: Cache
         id: cache-python


### PR DESCRIPTION
- chore(deps): update abatilo/actions-poetry action to v3
- Fix python version in github actions - Force using python version what it is specified by build matrix - This PR includes #382   - After abatilo/actions-poetry action to v3, `pipx` is used instead of `pip`   - `pipx` may use python version which is not specified by build matrix     - This PR fixes it     - It should be specified explicitly
