### PR TITLE
Add installation instructions to README

### DIFF
--- a/packages/hello/README.md
+++ b/packages/hello/README.md
@@ -4,6 +4,23 @@
 
 This is a repository for creating sample code for publishing to PyPI.
 
+## Installation
+
+This is not published to PyPI, so you need to install it from github.
+You can also install it via local clone.
+
+### Install via pip
+
+```sh
+$ pip install 'git+https://github.com/kitsuyui/ml-playground.git#egg=kitsuyui_ml.hello&subdirectory=packages/hello'
+```
+
+### Install via uv
+
+```sh
+$ uv add 'https://github.com/kitsuyui/ml-playground.git#egg=kitsuyui_ml.hello&subdirectory=packages/hello'
+```
+
 # LICENSE
 
 BSD 3-Clause License

--- a/packages/torch_ext/README.md
+++ b/packages/torch_ext/README.md
@@ -9,6 +9,23 @@ Implement basic PyTorch extensions for training
 - CategoricalEmbedding
 - TokenEmbedding
 
+## Installation
+
+This is not published to PyPI, so you need to install it from github.
+You can also install it via local clone.
+
+### Install via pip
+
+```sh
+$ pip install 'git+https://github.com/kitsuyui/ml-playground.git#egg=kitsuyui_ml.torch_ext&subdirectory=packages/torch_ext'
+```
+
+### Install via uv
+
+```sh
+$ uv add 'https://github.com/kitsuyui/ml-playground.git#egg=kitsuyui_ml.torch_ext&subdirectory=packages/torch_ext'
+```
+
 # LICENSE
 
 BSD 3-Clause License


### PR DESCRIPTION
- pip installation from git repositories often results in complicated URLs, so I felt it was necessary to document it.
