### PR TITLE
Fix installation example URLs

### DIFF
--- a/packages/hello/README.md
+++ b/packages/hello/README.md
@@ -18,7 +18,7 @@ $ pip install 'git+https://github.com/kitsuyui/ml-playground.git#egg=kitsuyui_ml
 ### Install via uv
 
 ```sh
-$ uv add 'https://github.com/kitsuyui/ml-playground.git#egg=kitsuyui_ml.hello&subdirectory=packages/hello'
+$ uv add 'git+https://github.com/kitsuyui/ml-playground.git#egg=kitsuyui_ml.hello&subdirectory=packages/hello'
 ```
 
 # LICENSE

--- a/packages/mini_vocab/README.md
+++ b/packages/mini_vocab/README.md
@@ -21,7 +21,7 @@ $ pip install 'git+https://github.com/kitsuyui/ml-playground.git#egg=kitsuyui_ml
 ### Install via uv
 
 ```sh
-$ uv add 'https://github.com/kitsuyui/ml-playground.git#egg=kitsuyui_ml.mini_vocab&subdirectory=packages/mini_vocab'
+$ uv add 'git+https://github.com/kitsuyui/ml-playground.git#egg=kitsuyui_ml.mini_vocab&subdirectory=packages/mini_vocab'
 ```
 
 # LICENSE

--- a/packages/torch_ext/README.md
+++ b/packages/torch_ext/README.md
@@ -23,7 +23,7 @@ $ pip install 'git+https://github.com/kitsuyui/ml-playground.git#egg=kitsuyui_ml
 ### Install via uv
 
 ```sh
-$ uv add 'https://github.com/kitsuyui/ml-playground.git#egg=kitsuyui_ml.torch_ext&subdirectory=packages/torch_ext'
+$ uv add 'git+https://github.com/kitsuyui/ml-playground.git#egg=kitsuyui_ml.torch_ext&subdirectory=packages/torch_ext'
 ```
 
 # LICENSE


### PR DESCRIPTION
The installation instructions in the README files were incorrect.
The URLs for installing via `uv` were missing the `git+` prefix, which is
required for proper functionality. This commit corrects those URLs.
