### PR TITLE
Implementing generate_square_subsequent_mask

### DIFF
--- a/packages/torch_ext/src/kitsuyui_ml/torch_ext/generate_subsequent_mask.py
+++ b/packages/torch_ext/src/kitsuyui_ml/torch_ext/generate_subsequent_mask.py
@@ -1,0 +1,53 @@
+"""
+generate square subsequent mask for transformer models.
+
+nin = float("-inf")  # for short-hand notation
+when the given size is 5, the mask will look like this:
+
+tensor = torch.Tensor([
+    [0.0, nin, nin, nin, nin],
+    [0.0, 0.0, nin, nin, nin],
+    [0.0, 0.0, 0.0, nin, nin],
+    [0.0, 0.0, 0.0, 0.0, nin],
+    [0.0, 0.0, 0.0, 0.0, 0.0],
+])
+
+this prevents the model from looking ahead in the sequence,
+"""
+
+import torch
+
+
+def generate_square_subsequent_mask_1(
+    size: int, *, device: torch.device | None = None
+) -> torch.Tensor:
+    """
+    Generate a square subsequent mask for a transformer model.
+    Args:
+        size (int): The size of the mask (number of tokens).
+        device (torch.device, optional): The device to create the mask on. Defaults to "cpu".
+    Returns:
+        torch.Tensor: A square mask of shape (size, size) with the upper triangular part masked out.
+    The mask is filled with 0.0 for valid positions and -inf for masked positions
+    """
+    mask = (torch.triu(torch.ones((size, size), device=device)) == 1).transpose(0, 1)
+    mask = (
+        mask.float().masked_fill(mask == 0, float("-inf")).masked_fill(mask == 1, 0.0)
+    )
+    return mask
+
+
+def generate_square_subsequent_mask_2(
+    size: int, *, device: torch.device | None = None
+) -> torch.Tensor:
+    """
+    Generate a square subsequent mask for a transformer model.
+    Args:
+        size (int): The size of the mask (number of tokens).
+        device (torch.device, optional): The device to create the mask on. Defaults to "cpu".
+    Returns:
+        torch.Tensor: A square mask of shape (size, size) with the upper triangular part masked out.
+    The mask is filled with 0.0 for valid positions and -inf for masked positions
+    """
+    mask = torch.nn.Transformer.generate_square_subsequent_mask(size, device=device)
+    return mask

--- a/packages/torch_ext/tests/test_generate_subsequent_mask.py
+++ b/packages/torch_ext/tests/test_generate_subsequent_mask.py
@@ -1,0 +1,54 @@
+from kitsuyui_ml.torch_ext.generate_subsequent_mask import (
+    generate_square_subsequent_mask_1,
+    generate_square_subsequent_mask_2,
+)
+
+import torch
+
+
+def test_generate_square_subsequent_mask_1() -> None:
+    mask = generate_square_subsequent_mask_1(5)
+    nin = float("-inf")
+    tobe = torch.Tensor(
+        [
+            [0.0, nin, nin, nin, nin],
+            [0.0, 0.0, nin, nin, nin],
+            [0.0, 0.0, 0.0, nin, nin],
+            [0.0, 0.0, 0.0, 0.0, nin],
+            [0.0, 0.0, 0.0, 0.0, 0.0],
+        ]
+    )
+    assert (mask == tobe).all()
+    assert mask.shape == (5, 5)
+    assert mask.dtype == torch.float32
+    assert mask.device == torch.device("cpu")
+
+    # Test the edge cases when size is 0 or 1
+    size_0 = 0
+    mask_0 = generate_square_subsequent_mask_1(size_0)
+    assert mask_0.shape == (0, 0)
+    assert mask_0.dtype == torch.float32
+    assert mask_0.device == torch.device("cpu")
+    size_1 = 1
+    mask_1 = generate_square_subsequent_mask_1(size_1)
+    assert mask_1.shape == (1, 1)
+    assert mask_1.dtype == torch.float32
+    assert mask_1.device == torch.device("cpu")
+
+
+def test_generate_square_subsequent_mask_2() -> None:
+    mask = generate_square_subsequent_mask_2(5)
+    nin = float("-inf")
+    tobe = torch.Tensor(
+        [
+            [0.0, nin, nin, nin, nin],
+            [0.0, 0.0, nin, nin, nin],
+            [0.0, 0.0, 0.0, nin, nin],
+            [0.0, 0.0, 0.0, 0.0, nin],
+            [0.0, 0.0, 0.0, 0.0, 0.0],
+        ]
+    )
+    assert (mask == tobe).all()
+    assert mask.shape == (5, 5)
+    assert mask.dtype == torch.float32
+    assert mask.device == torch.device("cpu")


### PR DESCRIPTION
The generate_square_subsequent_mask is already implemented in torch.nn.Transformer, but this sample implements it without relying on that.
