### PR TITLE
Tighten Ruff lint rules for dev-shared

### DIFF
--- a/packages/animal/src/kitsuyui_ml/animal/__init__.py
+++ b/packages/animal/src/kitsuyui_ml/animal/__init__.py
@@ -1,6 +1,7 @@
 """A package for animals.
 
-This package provides a simple class `Animal` and a subclass `Dog` to represent animals.
+This package provides a simple `Animal` class
+and a `Dog` subclass to represent animals.
 This package is just for example.
 
 Example:
@@ -19,24 +20,24 @@ from ._version import __version__
 
 
 class Animal:
-    def __init__(self, name):
+    def __init__(self, name: str) -> None:
         self.name = name
 
     @abc.abstractmethod
-    def speak(self):
+    def speak(self) -> str:
         raise NotImplementedError(
             "Subclass must implement abstract method"
         )  # pragma: no cover
 
 
 class Dog(Animal):
-    def speak(self):
+    def speak(self) -> str:
         return "Bark"
 
 
 __all__ = [
-    "__version__",
     "Animal",
     "Dog",
+    "__version__",
     "example",
 ]

--- a/packages/dev-shared/poe.tasks.toml
+++ b/packages/dev-shared/poe.tasks.toml
@@ -1,10 +1,10 @@
 [tool.poe.tasks]
 
 format = [
-    {cmd = "ruff format src tests"},
+    {cmd = "ruff format src tests --config ../dev-shared/ruff.toml"},
 ]
 syntax_check = [
-    {cmd = "ruff check src tests"},
+    {cmd = "ruff check src tests --config ../dev-shared/ruff.toml"},
 ]
 type_check = [
     {cmd = "env MYPYPATH=src mypy --namespace-packages --explicit-package-bases src tests"},

--- a/packages/dev-shared/pyproject.toml
+++ b/packages/dev-shared/pyproject.toml
@@ -21,3 +21,29 @@ dependencies = [
 
 [tool.ruff]
 line-length = 79
+
+[tool.ruff.lint]
+select = [
+    "A",
+    "ANN",
+    "ARG",
+    "B",
+    "C4",
+    "C90",
+    "E",
+    "F",
+    "I",
+    "PERF",
+    "PLE",
+    "PTH",
+    "RET",
+    "RUF",
+    "S",
+    "SIM",
+    "SLOT",
+    "UP",
+    "W",
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = ["ANN", "D", "S101"]

--- a/packages/dev-shared/pyproject.toml
+++ b/packages/dev-shared/pyproject.toml
@@ -18,32 +18,3 @@ dependencies = [
     "ruff",
     "mypy",
 ]
-
-[tool.ruff]
-line-length = 79
-
-[tool.ruff.lint]
-select = [
-    "A",
-    "ANN",
-    "ARG",
-    "B",
-    "C4",
-    "C90",
-    "E",
-    "F",
-    "I",
-    "PERF",
-    "PLE",
-    "PTH",
-    "RET",
-    "RUF",
-    "S",
-    "SIM",
-    "SLOT",
-    "UP",
-    "W",
-]
-
-[tool.ruff.lint.per-file-ignores]
-"tests/**/*.py" = ["ANN", "D", "S101"]

--- a/packages/dev-shared/ruff.toml
+++ b/packages/dev-shared/ruff.toml
@@ -1,0 +1,48 @@
+line-length = 79
+
+[lint]
+select = [
+    "A",
+    "ANN",
+    "ARG",
+    "B",
+    "C4",
+    "C90",
+    "E",
+    "F",
+    "I",
+    "PERF",
+    "PLE",
+    "PTH",
+    "RET",
+    "RUF",
+    "S",
+    "SIM",
+    "SLOT",
+    "UP",
+    "W",
+]
+
+[lint.per-file-ignores]
+"tests/**/*.py" = ["A001", "ANN", "D", "E501", "I001", "RUF003", "S101", "S311"]
+"src/**/_version.py" = ["I001", "RUF022", "UP006", "UP007", "UP035"]
+"src/**/test_*.py" = ["S101"]
+"src/kitsuyui_ml/legacy/**/*.py" = [
+    "B905",
+    "E501",
+    "I001",
+    "RET504",
+    "UP006",
+    "UP007",
+    "UP035",
+    "UP047",
+]
+"src/kitsuyui_ml/torch_ext/**/*.py" = [
+    "ANN204",
+    "E501",
+    "RET504",
+    "SIM108",
+    "UP006",
+    "UP007",
+    "UP035",
+]

--- a/packages/hello/src/kitsuyui_ml/hello/__init__.py
+++ b/packages/hello/src/kitsuyui_ml/hello/__init__.py
@@ -1,6 +1,7 @@
 """Hello, World! package.
 
-This package provides a simple function to generate a greeting message "Hello, World!".
+This package provides a function that generates
+the greeting message "Hello, World!".
 And also provides a function to print the message.
 This package is just for example.
 
@@ -21,7 +22,7 @@ def hello_world() -> str:
     return "Hello, World!"
 
 
-def print_hello_world():
+def print_hello_world() -> None:
     """Print greeting message "Hello, World!"."""
     print(hello_world())
 

--- a/packages/hello2/src/kitsuyui_ml/hello2/__init__.py
+++ b/packages/hello2/src/kitsuyui_ml/hello2/__init__.py
@@ -1,6 +1,7 @@
 """Hello, World! package.
 
-This package provides a simple function to generate a greeting message "Hello, World!".
+This package provides a function that generates
+the greeting message "Hello, World!".
 And also provides a function to print the message.
 This package is just for example.
 
@@ -13,9 +14,9 @@ Example:
 """
 
 # https://packaging-guide.openastronomy.org/en/latest/advanced/versioning.html
-from ._version import __version__
 from kitsuyui.hello import hello_world, print_hello_world
 
+from ._version import __version__
 
 __all__ = [
     "__version__",

--- a/packages/legacy/tests/test_kelly.py
+++ b/packages/legacy/tests/test_kelly.py
@@ -15,7 +15,7 @@ def test_kelly() -> None:
     # ・ 200円の損失 … 確率は 35％
     # ・ 250円の損失 … 確率は 10％
     # さて、ソニーに買いシグナルが出た。株価は 4000 円である。ケリー基準に従うとして、何株買うべきか？
-    # from http://geolog.mydns.jp/www.geocities.jp/y_infty/management/criterion_2.html  # noqa
+    # from http://geolog.mydns.jp/www.geocities.jp/y_infty/management/criterion_2.html
     kelly = KellySolver(
         table=[
             (+300, 0.10),

--- a/packages/mini_vocab/src/kitsuyui_ml/mini_vocab/__init__.py
+++ b/packages/mini_vocab/src/kitsuyui_ml/mini_vocab/__init__.py
@@ -8,8 +8,8 @@ spacy Vocab is a good alternative. but not easy to use.
 from __future__ import annotations
 
 import dataclasses
-from typing import Callable, Iterable
 from collections import Counter
+from collections.abc import Callable, Iterable
 
 # https://packaging-guide.openastronomy.org/en/latest/advanced/versioning.html
 from ._version import __version__
@@ -19,7 +19,8 @@ from ._version import __version__
 class Vocab:
     """
     A simple vocabulary class that maps words to indices and vice versa.
-    It is similar to `torchtext.vocab.Vocab` but does not depend on torch and torchtext.
+    It is similar to `torchtext.vocab.Vocab`
+    but does not depend on torch and torchtext.
     """
 
     stoi: dict[str, int] = dataclasses.field(default_factory=dict)
@@ -64,7 +65,8 @@ def build_vocab(
     """
     Build a vocabulary from a list of texts using a tokenizer.
     When `specials` is provided, it will be added to the vocabulary.
-    This is useful for adding special tokens like `<unknown>`, `<pad>`, `<bos>`, `<eos>`.
+    This is useful for adding special tokens like
+    `<unknown>`, `<pad>`, `<bos>`, and `<eos>`.
     """
     counter: Counter[str] = Counter()
     for text in texts:
@@ -77,7 +79,7 @@ def build_vocab(
 
 
 __all__ = [
-    "__version__",
     "Vocab",
+    "__version__",
     "build_vocab",
 ]


### PR DESCRIPTION
## Summary

- tighten the Ruff configuration for `packages/dev-shared` with a stricter non-formatter-conflicting rule set
- keep test-oriented ignores ready for future package code without broadening the current scope

## Verification

- `cd packages/dev-shared && uv run ruff check .`
