### PR TITLE
Add actionlint check for workflows

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -9,6 +9,22 @@ on:
       - main
 
 jobs:
+  actionlint:
+    name: Actionlint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: stable
+
+      - name: Run actionlint
+        run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/*.yml
+
   test:
     runs-on: macos-latest
     strategy:
@@ -46,7 +62,7 @@ jobs:
         run: |
           actual_version=$(uv run python --version)
           expected_version="Python ${{ matrix.python }}"
-          if [ "$actual_version" == *"$expected_version"* ]; then
+          if [[ "$actual_version" != *"$expected_version"* ]]; then
             echo "Expected $expected_version, but got $actual_version"
             exit 1
           fi
@@ -56,4 +72,3 @@ jobs:
 
       - name: Coverage
         run: uv run poe coverage
-


### PR DESCRIPTION
## Summary

- add an Actionlint job to the Python test workflow
- fix the Python version check shell fragment so it uses `[[ ... ]]` for glob matching
- fail only when the detected Python version does not match the matrix version

## Verification

- `actionlint .github/workflows/*.yml`
- `git diff --check`
- `uv run poe check`
- `uv run poe test`
