### PR TITLE
Add generated artifact guard

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v7
 
+      - name: Check generated artifacts
+        run: ./bin/check-generated-artifacts
+
       - name: Install dependencies
         run: |
           uv python pin ${{ matrix.python }}

--- a/bin/check-generated-artifacts
+++ b/bin/check-generated-artifacts
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly generated_artifact_pattern='(^|/)(__pycache__|\.mypy_cache|\.pytest_cache|\.ruff_cache|[^/]+\.egg-info)(/|$)'
+
+tracked_artifacts="$(git ls-files | grep -E "${generated_artifact_pattern}" || true)"
+
+if [[ -n "${tracked_artifacts}" ]]; then
+  cat <<'EOF' >&2
+Generated Python artifacts are tracked by git.
+Remove these paths from the index and keep the source files as the source of truth:
+EOF
+  printf '%s\n' "${tracked_artifacts}" >&2
+  exit 1
+fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,3 +45,4 @@ type_check = { cmd = "./bin/run-each type_check" }
 test = { cmd = "./bin/run-each test" }
 coverage = { shell = "cd \"$(git rev-parse --show-toplevel)\" && rm -f coverage.xml .coverage && ./bin/run-each coverage && uv run python -m coverage combine packages/*/.coverage && uv run python -m coverage xml -o coverage.xml" }
 build = { cmd = "./bin/run-each build" }
+generated_artifact_check = { cmd = "./bin/check-generated-artifacts" }


### PR DESCRIPTION
## Summary

- add a repository guard that fails when Python-generated artifacts are tracked
- expose the guard as a Poe task for local use
- run the guard in the Python CI workflow before dependency installation

## Validation

- `./bin/check-generated-artifacts`
- `uv run poe generated_artifact_check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/*.yml`
- `typos`
- `git diff --check`
