### PR TITLE
Use reusable actionlint and gh-counter workflows

### DIFF
--- a/.github/workflows/gh-counter.yml
+++ b/.github/workflows/gh-counter.yml
@@ -11,21 +11,4 @@ permissions:
 
 jobs:
   gh-counter:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Count type-ignore markers
-        uses: kitsuyui/gh-counter@v1.2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload gh-counter output
-        uses: actions/upload-artifact@v4
-        with:
-          name: gh-counter-output
-          path: .gh-counter
-          include-hidden-files: true
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/gh-counter.yml@main

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -10,21 +10,7 @@ on:
 
 jobs:
   actionlint:
-    name: Actionlint
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: stable
-
-      - name: Run actionlint
-        run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/*.yml
-
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/actionlint.yml@main
   test:
     runs-on: macos-latest
     strategy:


### PR DESCRIPTION
## Summary
- Replace local actionlint and/or gh-counter job definitions with reusable workflow callers from `kitsuyui/gh-actions-workflows`.
- Keep repository-specific workflow triggers and permissions unchanged.

## Changed files
- `.github/workflows/gh-counter.yml`
- `.github/workflows/python-test.yml`

## Validation
- `actionlint -color=false <updated workflow files>`
- `git diff --check`
