### PR TITLE
Pin octocov workflow actions

### DIFF
--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -19,7 +19,7 @@ jobs:
         python: ["3.13"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: install shared libraries
         run: |
@@ -28,12 +28,12 @@ jobs:
 
       - name: Set up Python
         id: setup-python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "${{ matrix.python }}"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Install dependencies
         run: |
@@ -48,7 +48,7 @@ jobs:
 
       # See also: https://github.com/k1LoW/octocov-action
       - name: Report coverage with octocov
-        uses: k1LoW/octocov-action@v1
+        uses: k1LoW/octocov-action@b3b6ee60482a667950f87553abf1df63217235d9 # v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           config: .octocov.yml


### PR DESCRIPTION
## Summary

- Pin the octocov workflow's third-party actions to full commit SHAs.
- Keep the original tag names as inline comments for review and future updates.

## Validation

- `git diff --check`
- YAML parse for `.github/workflows/octocov.yml`
- `actionlint .github/workflows/octocov.yml`
- `uv sync`
- `uv run poe check`
- `uv run poe test`
- `uv run poe coverage`

## Notes

`uv run poe test` and `uv run poe coverage` still report existing PyTorch deprecation warnings from the test environment, but both commands exit successfully. Generated coverage files were removed and are not included in this PR.
