### PR TITLE
Pin remaining workflow actions to commit SHAs

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   actionlint:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/actionlint.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/actionlint.yml@a7071a4635eaece62696cd7132306616ce283c47
   test:
     runs-on: macos-latest
     strategy:
@@ -20,7 +20,7 @@ jobs:
         python: ["3.12", "3.13"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: install shared libraries
         run: |
@@ -29,12 +29,12 @@ jobs:
 
       - name: Set up Python
         id: setup-python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "${{ matrix.python }}"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Check generated artifacts
         run: ./bin/check-generated-artifacts

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -5,4 +5,4 @@ permissions:
   contents: read
 jobs:
   check:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@a7071a4635eaece62696cd7132306616ce283c47


### PR DESCRIPTION
## Summary

- Pin every external `uses:` reference in `.github/workflows/python-test.yml` and `.github/workflows/spellcheck.yml` to a 40-character commit SHA so the CI/CD supply-chain input is fixed
- Match the SHAs already pinned by `.github/workflows/octocov.yml` for `actions/checkout` (v6), `actions/setup-python` (v6) and `astral-sh/setup-uv` (v7); pin `kitsuyui/gh-actions-workflows` to the same SHA the other reusable-workflow consumers in this repository use, so Renovate can bump every consumer together
- No behavioral change is intended

## Test plan

- [ ] `Lint and Test Python` workflow succeeds on the PR
- [ ] `Spellcheck` workflow succeeds on the PR
- [ ] `actionlint` reusable workflow succeeds at the pinned SHA