### PR TITLE
Add concurrency control to GitHub Actions workflows

### DIFF
--- a/.github/workflows/gh-counter.yml
+++ b/.github/workflows/gh-counter.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/happy.yml
+++ b/.github/workflows/happy.yml
@@ -1,6 +1,11 @@
 name: happy-commit
 on:
   - pull_request
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   actionlint:
     uses: kitsuyui/gh-actions-workflows/.github/workflows/actionlint.yml@a7071a4635eaece62696cd7132306616ce283c47

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,6 +1,11 @@
 name: Spellcheck
 on:
   - pull_request
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
## Summary

Add top-level `concurrency` settings to the GitHub Actions workflows that run on `pull_request` and/or `push`:

- `.github/workflows/gh-counter.yml`
- `.github/workflows/happy.yml`
- `.github/workflows/octocov.yml`
- `.github/workflows/python-test.yml`
- `.github/workflows/spellcheck.yml`

Each workflow now uses:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: true
```

## Motivation

When multiple commits are pushed to the same pull request or branch in quick succession, older workflow runs continue running even after they are no longer relevant. This change ensures that only the latest run for the same workflow and PR/branch stays active.

## Impact

- Cancels outdated in-progress runs for the same workflow on the same PR or branch
- Reduces unnecessary GitHub Actions usage
- Makes CI results easier to read by keeping the latest run authoritative

## Verification

- `git diff --check`
- `actionlint .github/workflows/*.yml`
- `typos .github/workflows/*.yml`
