### PR TITLE
fix: apply dropout in PositionWiseFeedForwardNetwork.forward()

### DIFF
--- a/packages/torch_ext/src/kitsuyui_ml/torch_ext/ffn.py
+++ b/packages/torch_ext/src/kitsuyui_ml/torch_ext/ffn.py
@@ -15,6 +15,7 @@ class PositionWiseFeedForwardNetwork(nn.Module):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         ys = self.linear1(x)
         ys = F.relu(ys)
+        ys = self.dropout(ys)
         return self.linear2(ys)  # type: ignore
 
 


### PR DESCRIPTION
`PositionWiseFeedForwardNetwork.__init__` creates `self.dropout = nn.Dropout(dropout)` but
`forward()` never called it, so dropout had no effect during training regardless of the
`dropout` parameter value.

This adds the missing `self.dropout(ys)` call between ReLU and the second linear layer,
matching the Position-wise Feed-Forward formulation in "Attention is All You Need"
(FFN(x) = max(0, xW₁+b₁)_dropout · W₂+b₂).

**Change**: `packages/torch_ext/src/kitsuyui_ml/torch_ext/ffn.py`
- Added `ys = self.dropout(ys)` after ReLU in `forward()`

**Verification**: format (`ruff format`), lint (`ruff check`), and tests (pytest) all pass.
