### PR TITLE
fix: raise ValueError for empty colors in choose_best_contrast_color()

### DIFF
--- a/packages/legacy/src/kitsuyui_ml/legacy/algorithms/luminance.py
+++ b/packages/legacy/src/kitsuyui_ml/legacy/algorithms/luminance.py
@@ -123,6 +123,8 @@ def choose_best_contrast_color(
     This function is useful for choosing a better monochrome text color for a given background color.
     But this function only works for monochrome colors. It does not work for colors with different hues.
     """
+    if not colors:
+        raise ValueError("colors must not be empty")
     fixed_color_luminance = relative_luminance_from_hex(fixed_color)
     luminances = [relative_luminance_from_hex(color) for color in colors]
     contrast_ratios = [

--- a/packages/legacy/tests/test_luminance.py
+++ b/packages/legacy/tests/test_luminance.py
@@ -64,3 +64,8 @@ def test_choose_best_contrast_color() -> None:
 def test_hex_color_to_rgb_invalid_length_raises(invalid_hex: str) -> None:
     with pytest.raises(ValueError, match="Invalid hex color"):
         luminance.hex_color_to_rgb(invalid_hex)
+
+
+def test_choose_best_contrast_color_empty_raises() -> None:
+    with pytest.raises(ValueError, match="empty"):
+        luminance.choose_best_contrast_color("#FFFFFF", [])


### PR DESCRIPTION
## Summary

`choose_best_contrast_color()` accepted `colors: list[str]` but had no guard for the empty case. When `colors` was empty, `max(contrast_ratios)` raised `ValueError: max() arg is an empty sequence` — a confusing message that doesn't name the constraint.

This change adds an explicit `if not colors: raise ValueError("colors must not be empty")` at the function entry, giving callers a clear signal when they accidentally pass an empty palette.

## Changes

- `packages/legacy/src/kitsuyui_ml/legacy/algorithms/luminance.py`: add empty-list guard in `choose_best_contrast_color()`
- `packages/legacy/tests/test_luminance.py`: add `test_choose_best_contrast_color_empty_raises`

## Verification

```
$ uv run pytest packages/legacy/tests/test_luminance.py -v
6 passed in 0.01s

$ uv run poe check
All checks passed (ruff + mypy across all packages)
```

## Trade-offs

Raising is the simplest API-preserving fix. Callers who want to handle empty palettes gracefully can catch `ValueError`. A design-level alternative (returning `None` and changing the return type to `str | None`) would require updating all call sites and is not justified by a single finding.