### PR TITLE
Register ScaleEmbedding scale as a buffer

### DIFF
--- a/packages/torch_ext/src/kitsuyui_ml/torch_ext/scale_embedding.py
+++ b/packages/torch_ext/src/kitsuyui_ml/torch_ext/scale_embedding.py
@@ -16,7 +16,7 @@ class ScaleEmbedding(nn.Module):
             num_embeddings=num_embeddings,
             embedding_dim=embedding_dim,
         )
-        self.scale = torch.sqrt(torch.tensor(embedding_dim, requires_grad=False))
+        self.register_buffer("scale", torch.sqrt(torch.tensor(embedding_dim)))
 
     def forward(self, x: Tensor) -> Tensor:
         return self.embedding(x.long()) * self.scale  # type: ignore

--- a/packages/torch_ext/tests/test_scale_embedding.py
+++ b/packages/torch_ext/tests/test_scale_embedding.py
@@ -1,6 +1,9 @@
 import torch
 
-from kitsuyui_ml.torch_ext.scale_embedding import ScaleEmbedding, ScaleEmbedding2
+from kitsuyui_ml.torch_ext.scale_embedding import (
+    ScaleEmbedding,
+    ScaleEmbedding2,
+)
 
 
 def test_scale_embedding() -> None:
@@ -14,6 +17,10 @@ def test_scale_embedding() -> None:
     se = ScaleEmbedding(num_embeddings, embedding_dim)
     y = se(x)
     assert y.shape == (input_dim, embedding_dim)
+    assert "scale" in se.state_dict()
+
+    se = se.to(dtype=torch.float64)
+    assert se.scale.dtype == torch.float64
 
     # Test 2
     se2 = ScaleEmbedding2(num_embeddings, embedding_dim)


### PR DESCRIPTION
## Summary
- Register `ScaleEmbedding.scale` as a PyTorch buffer so it is included in `state_dict()` and follows module conversions.
- Add coverage for `state_dict()` serialization and dtype conversion behavior.

## Validation
- `uv sync --all-packages`
- `uv run poe check` from `packages/torch_ext`
- `uv run poe test` from `packages/torch_ext`
- `uv run ruff format src/kitsuyui_ml/torch_ext/scale_embedding.py tests/test_scale_embedding.py --check --config ../dev-shared/ruff.toml` from `packages/torch_ext`
- `git diff --check`
