### PR TITLE
fix: validate hex color length in hex_color_to_rgb()

### DIFF
--- a/packages/legacy/src/kitsuyui_ml/legacy/algorithms/luminance.py
+++ b/packages/legacy/src/kitsuyui_ml/legacy/algorithms/luminance.py
@@ -58,10 +58,14 @@ def relative_luminance_from_hex(hex_color: str) -> float:
 
 def hex_color_to_rgb(hex_color: str) -> tuple[Uint8, Uint8, Uint8]:
     """Convert a hex color string to an RGB tuple."""
-    hex_color = hex_color.lstrip("#")
-    if len(hex_color) == 3:
-        hex_color = "".join(2 * s for s in hex_color)
-    r_hex, g_hex, b_hex = hex_color[:2], hex_color[2:4], hex_color[4:]
+    stripped = hex_color.lstrip("#")
+    if len(stripped) == 3:
+        stripped = "".join(2 * s for s in stripped)
+    if len(stripped) != 6:
+        raise ValueError(
+            f"Invalid hex color: {hex_color!r}. Expected '#RGB' or '#RRGGBB'."
+        )
+    r_hex, g_hex, b_hex = stripped[:2], stripped[2:4], stripped[4:]
     r, g, b = int(r_hex, 16), int(g_hex, 16), int(b_hex, 16)
     return r, g, b
 
@@ -122,7 +126,8 @@ def choose_best_contrast_color(
     fixed_color_luminance = relative_luminance_from_hex(fixed_color)
     luminances = [relative_luminance_from_hex(color) for color in colors]
     contrast_ratios = [
-        contrast_ratio(fixed_color_luminance, luminance) for luminance in luminances
+        contrast_ratio(fixed_color_luminance, luminance)
+        for luminance in luminances
     ]
     max_contrast_ratio = max(contrast_ratios)
     max_contrast_ratio_index = contrast_ratios.index(max_contrast_ratio)

--- a/packages/legacy/tests/test_luminance.py
+++ b/packages/legacy/tests/test_luminance.py
@@ -1,3 +1,5 @@
+import pytest
+
 import kitsuyui_ml.legacy.algorithms.luminance as luminance
 
 
@@ -43,4 +45,22 @@ def test_choose_best_contrast_color() -> None:
         luminance.choose_best_contrast_color("#CCCCCC", ["#111111", "#EEEEEE"])
         == "#111111"
     )
-    assert luminance.choose_best_contrast_color("#000", ["#000", "#FFF"]) == "#FFF"
+    assert (
+        luminance.choose_best_contrast_color("#000", ["#000", "#FFF"])
+        == "#FFF"
+    )
+
+
+@pytest.mark.parametrize(
+    "invalid_hex",
+    [
+        "",
+        "#",
+        "#12345",
+        "#1234567",
+        "\uff03FFFFFF",
+    ],
+)
+def test_hex_color_to_rgb_invalid_length_raises(invalid_hex: str) -> None:
+    with pytest.raises(ValueError, match="Invalid hex color"):
+        luminance.hex_color_to_rgb(invalid_hex)


### PR DESCRIPTION
## Summary

- `hex_color_to_rgb()` raised no error when the hex string length (after stripping `#`) was not 3 or 6 — e.g. empty string, 5-char, 7-char, or full-width `＃` prefix.
- Add an explicit length check: raise `ValueError` with a descriptive message before reaching the `int(..., 16)` slice.
- Add parametrized tests covering `""`, `"#"`, `"#12345"`, `"#1234567"`, and `"＃FFFFFF"` (full-width prefix).

## Changes

- `packages/legacy/src/kitsuyui_ml/legacy/algorithms/luminance.py`: guard in `hex_color_to_rgb()` after the 3→6 expansion step
- `packages/legacy/tests/test_luminance.py`: new `test_hex_color_to_rgb_invalid_length_raises` parametrized test

## Verification

```
uv run poe test   # 51 passed
uv run poe check  # ruff + mypy: no issues
```

## Trade-offs

The fix is a minimal surface change. Non-hex characters (e.g. `GGGGGG`) still raise `ValueError` from `int()` with a different message; that is pre-existing behaviour and out of scope here.
