### PR TITLE
Reject infinite losses in EarlyStopping

### DIFF
--- a/packages/legacy/src/kitsuyui_ml/legacy/early_stopping.py
+++ b/packages/legacy/src/kitsuyui_ml/legacy/early_stopping.py
@@ -11,19 +11,33 @@ class EarlyStopping:
     best_loss: float = float("inf")
 
     def __call__(self, loss: float) -> bool:
-        is_best_loss = self.is_best_loss(loss)
-        self.step(loss)
+        self._validate_loss(loss)
+        is_best_loss = self._is_best_loss_unchecked(loss)
+        self._step_unchecked(loss)
         return is_best_loss
+
+    @staticmethod
+    def _validate_loss(loss: float) -> None:
+        if math.isnan(loss):
+            raise ValueError("NaN loss: possible gradient explosion")
+        if math.isinf(loss):
+            raise ValueError("Infinite loss: possible gradient explosion")
 
     def is_best_loss(self, loss: float) -> bool:
         """Check if loss is better than current best loss."""
+        self._validate_loss(loss)
+        return self._is_best_loss_unchecked(loss)
+
+    def _is_best_loss_unchecked(self, loss: float) -> bool:
         return loss <= self.best_loss
 
     def step(self, loss: float) -> None:
         """Update early stopping state."""
-        if math.isnan(loss):
-            raise ValueError("NaN loss: possible gradient explosion")
-        if self.is_best_loss(loss):
+        self._validate_loss(loss)
+        self._step_unchecked(loss)
+
+    def _step_unchecked(self, loss: float) -> None:
+        if self._is_best_loss_unchecked(loss):
             self.best_loss = loss
             self.count = 0
         else:

--- a/packages/legacy/tests/test_early_stopping.py
+++ b/packages/legacy/tests/test_early_stopping.py
@@ -23,3 +23,28 @@ def test_early_stopping_nan_loss_raises() -> None:
     es(loss=1.0)
     with pytest.raises(ValueError, match="NaN"):
         es(loss=float("nan"))
+
+
+@pytest.mark.parametrize("loss", [float("inf"), -float("inf")])
+def test_early_stopping_infinite_loss_raises_without_resetting_state(
+    loss: float,
+) -> None:
+    es = EarlyStopping(patience=3)
+    es(loss=1.0)
+    es(loss=1.1)
+    count = es.count
+    best_loss = es.best_loss
+
+    with pytest.raises(ValueError, match="Infinite"):
+        es(loss=loss)
+
+    assert es.count == count
+    assert es.best_loss == best_loss
+
+
+@pytest.mark.parametrize("loss", [float("inf"), -float("inf")])
+def test_is_best_loss_rejects_infinite_loss(loss: float) -> None:
+    es = EarlyStopping(patience=3)
+
+    with pytest.raises(ValueError, match="Infinite"):
+        es.is_best_loss(loss)


### PR DESCRIPTION
## Summary
- reject positive and negative infinite losses before EarlyStopping compares or updates state
- keep the existing NaN loss guard behavior
- add regression tests covering infinite losses and direct `is_best_loss()` calls

## Validation
- `uv sync --all-packages --all-groups`
- `uv run python -m pytest packages/legacy/tests/test_early_stopping.py`
- `uv run poe test`
- `uv run poe check`
- `uv run ruff format --check packages/legacy/src/kitsuyui_ml/legacy/early_stopping.py packages/legacy/tests/test_early_stopping.py --config packages/dev-shared/ruff.toml`
- `git diff --check`
- `typos packages/legacy/src/kitsuyui_ml/legacy/early_stopping.py packages/legacy/tests/test_early_stopping.py`
