### PR TITLE
fix: raise RuntimeError when scipy.optimize.minimize fails to converge

### DIFF
--- a/packages/legacy/src/kitsuyui_ml/legacy/kelly/kelly.py
+++ b/packages/legacy/src/kitsuyui_ml/legacy/kelly/kelly.py
@@ -138,5 +138,9 @@ def arg_max_solver(*, variable: sympy.Expr, function: sympy.Expr) -> float:
         -function,  # inversed maximize is minimize
         "scipy",
     )
-    arg_max_values = scipy.optimize.minimize(function_in_scipy, 0).x
-    return float(arg_max_values[0])  # scipy -> float
+    result = scipy.optimize.minimize(function_in_scipy, 0)
+    if not result.success:
+        raise RuntimeError(
+            f"Optimization failed to converge: {result.message}"
+        )
+    return float(result.x[0])  # scipy -> float

--- a/packages/legacy/tests/test_kelly.py
+++ b/packages/legacy/tests/test_kelly.py
@@ -1,8 +1,11 @@
 """ケリー基準の計算のテスト"""
 
-import pytest
+from unittest.mock import MagicMock, patch
 
-from kitsuyui_ml.legacy.kelly.kelly import KellySolver
+import pytest
+import sympy  # type: ignore
+
+from kitsuyui_ml.legacy.kelly.kelly import KellySolver, arg_max_solver
 
 
 def test_kelly() -> None:
@@ -83,3 +86,17 @@ def test_kelly_error() -> None:
         2_000_000,
     )
     assert kelly_float.optimal_fraction == pytest.approx(0.0595, 0.001)
+
+
+def test_arg_max_solver_convergence_failure() -> None:
+    """RuntimeError is raised when scipy.optimize.minimize fails to converge."""
+    failed_result = MagicMock()
+    failed_result.success = False
+    failed_result.message = "Iteration limit exceeded"
+
+    x = sympy.Symbol("x")
+    with (
+        patch("scipy.optimize.minimize", return_value=failed_result),
+        pytest.raises(RuntimeError, match="Optimization failed to converge"),
+    ):
+        arg_max_solver(variable=x, function=x**2)


### PR DESCRIPTION
## Summary

`arg_max_solver()` in `packages/legacy/src/kitsuyui_ml/legacy/kelly/kelly.py` was accessing `.x` on the `scipy.optimize.minimize` result without checking `.success`. When optimization fails to converge (non-convex objective, iteration limit exceeded, etc.), the unconverged intermediate value was silently returned as the Kelly criterion optimal fraction.

## Change

- Check `OptimizeResult.success` before using `.x`
- Raise `RuntimeError` with `result.message` when optimization fails
- Add a test that mocks a failed result to cover the error path

## Verification

- All 54 existing tests pass
- New test `test_arg_max_solver_convergence_failure` covers the failure branch
- `ruff check` and `mypy` pass with no new errors

## Trade-offs

The caller (`KellySolver.optimal_fraction`) will now propagate `RuntimeError` upward on convergence failure. This is intentional: a silent wrong value is harder to debug than an explicit exception.
