### PR TITLE
Validate permutation_rank inputs

### DIFF
--- a/packages/legacy/src/kitsuyui_ml/legacy/algorithms/permutation_rank/permutation_rank.py
+++ b/packages/legacy/src/kitsuyui_ml/legacy/algorithms/permutation_rank/permutation_rank.py
@@ -46,6 +46,11 @@ class FenwickTree:
             i += i & -i
 
 
+def _ensure_distinct(values: List[T], name: str) -> None:
+    if len(set(values)) != len(values):
+        raise ValueError(f"{name} must contain distinct values")
+
+
 def permutation_rank(a: List[T], items: List[T]) -> int:
     """
     Compute the 0-based rank of the partial permutation a (length m) among
@@ -64,8 +69,15 @@ def permutation_rank(a: List[T], items: List[T]) -> int:
     """
     n = len(items)
     m = len(a)
+    if m > n:
+        raise ValueError("a must not be longer than items")
+    _ensure_distinct(items, "items")
+    _ensure_distinct(a, "a")
+
     # Map each item to its index in the sorted items list
     index_map = {item: i for i, item in enumerate(items)}
+    if any(ai not in index_map for ai in a):
+        raise ValueError("a must only contain values from items")
 
     fact = math.factorial
     denom = fact(n - m)

--- a/packages/legacy/src/kitsuyui_ml/legacy/algorithms/permutation_rank/test_permutation_rank.py
+++ b/packages/legacy/src/kitsuyui_ml/legacy/algorithms/permutation_rank/test_permutation_rank.py
@@ -1,3 +1,5 @@
+import pytest
+
 from .permutation_rank import permutation_rank
 
 
@@ -59,3 +61,19 @@ def test_permutation_rank() -> None:
 
     items2 = list(range(18))
     assert permutation_rank([0, 1, 2], items2) == 0
+
+
+@pytest.mark.parametrize(
+    ("a", "items", "match"),
+    [
+        (["A", "B"], ["A"], "longer than items"),
+        (["A"], ["A", "A"], "items must contain distinct values"),
+        (["A", "A"], ["A", "B"], "a must contain distinct values"),
+        (["C"], ["A", "B"], "values from items"),
+    ],
+)
+def test_permutation_rank_rejects_invalid_inputs(
+    a: list[str], items: list[str], match: str
+) -> None:
+    with pytest.raises(ValueError, match=match):
+        permutation_rank(a, items)


### PR DESCRIPTION
## Summary
- reject partial permutations that are longer than the item list before ranking
- reject duplicate values in either `a` or `items`
- raise `ValueError` when `a` contains values outside `items`

## Validation
- `uv sync --all-packages --all-groups`
- `uv run python -m pytest packages/legacy/src/kitsuyui_ml/legacy/algorithms/permutation_rank/test_permutation_rank.py`
- `./bin/check-generated-artifacts`
- `uv run poe check`
- `uv run poe test`
- `cd packages/legacy && uv run ruff check src/kitsuyui_ml/legacy/algorithms/permutation_rank/permutation_rank.py src/kitsuyui_ml/legacy/algorithms/permutation_rank/test_permutation_rank.py --config ../dev-shared/ruff.toml`
- `cd packages/legacy && uv run ruff format --check src/kitsuyui_ml/legacy/algorithms/permutation_rank/permutation_rank.py src/kitsuyui_ml/legacy/algorithms/permutation_rank/test_permutation_rank.py --config ../dev-shared/ruff.toml`
- `git diff --check`
- `typos packages/legacy/src/kitsuyui_ml/legacy/algorithms/permutation_rank/permutation_rank.py packages/legacy/src/kitsuyui_ml/legacy/algorithms/permutation_rank/test_permutation_rank.py`
