### PR TITLE
fix: align NumericalEmbedding parameter order with PyTorch convention

### DIFF
--- a/packages/torch_ext/src/kitsuyui_ml/torch_ext/generate_subsequent_mask.py
+++ b/packages/torch_ext/src/kitsuyui_ml/torch_ext/generate_subsequent_mask.py
@@ -30,9 +30,13 @@ def generate_square_subsequent_mask_1(
         torch.Tensor: A square mask of shape (size, size) with the upper triangular part masked out.
     The mask is filled with 0.0 for valid positions and -inf for masked positions
     """
-    mask = (torch.triu(torch.ones((size, size), device=device)) == 1).transpose(0, 1)
     mask = (
-        mask.float().masked_fill(mask == 0, float("-inf")).masked_fill(mask == 1, 0.0)
+        torch.triu(torch.ones((size, size), device=device)) == 1
+    ).transpose(0, 1)
+    mask = (
+        mask.float()
+        .masked_fill(mask == 0, float("-inf"))
+        .masked_fill(mask == 1, 0.0)
     )
     return mask
 
@@ -49,5 +53,7 @@ def generate_square_subsequent_mask_2(
         torch.Tensor: A square mask of shape (size, size) with the upper triangular part masked out.
     The mask is filled with 0.0 for valid positions and -inf for masked positions
     """
-    mask = torch.nn.Transformer.generate_square_subsequent_mask(size, device=device)
+    mask = torch.nn.Transformer.generate_square_subsequent_mask(
+        size, device=device
+    )
     return mask

--- a/packages/torch_ext/src/kitsuyui_ml/torch_ext/numerical_embedding.py
+++ b/packages/torch_ext/src/kitsuyui_ml/torch_ext/numerical_embedding.py
@@ -13,8 +13,8 @@ class NumericalEmbedding(nn.Module):
 
     def __init__(
         self,
-        embedding_dim: int,
         num_values: int,
+        embedding_dim: int,
         dropout: float,
     ) -> None:
         super().__init__()

--- a/packages/torch_ext/tests/test_scheduler.py
+++ b/packages/torch_ext/tests/test_scheduler.py
@@ -6,5 +6,7 @@ from kitsuyui_ml.torch_ext.scheduler import LRScheduler
 
 def test_scheduler() -> None:
     optimizer = torch.optim.SGD([torch.zeros(1)], lr=0.1)
-    scheduler: LRScheduler = torch.optim.lr_scheduler.ConstantLR(optimizer, 0.1)
+    scheduler: LRScheduler = torch.optim.lr_scheduler.ConstantLR(
+        optimizer, 0.1
+    )
     assert pytest.approx(scheduler.get_last_lr()) == [0.01]


### PR DESCRIPTION
## Summary

`NumericalEmbedding.__init__` accepted `(embedding_dim, num_values, dropout)`,
which is the reverse of PyTorch's standard `(num_*, embedding_dim)` order used
by `nn.Embedding`, `nn.EmbeddingBag`, and the sibling `CategoricalEmbedding` class.

This PR swaps the order to `(num_values, embedding_dim, dropout)` so callers
using both embedding classes see a consistent API surface.

## Impact

- All existing call sites use keyword arguments, so no call-site changes are required.
- Positional callers (if any arise) will now get the order matching PyTorch convention, reducing silent misconfiguration risk.

## Verification

- Existing tests pass without change (they already used keyword arguments).
- `ruff format` and `mypy` pass.