### PR TITLE
fix: align pick_max_steps_v3 tie-breaking with v1/v2 input-order behavior

### DIFF
--- a/packages/legacy/src/kitsuyui_ml/legacy/algorithms/pick_max_steps.py
+++ b/packages/legacy/src/kitsuyui_ml/legacy/algorithms/pick_max_steps.py
@@ -43,7 +43,9 @@ def pick_max_steps_v1(items: Items) -> Result:
     items = items[:]
     result = []
     while any(v > 0 for _, v in items):  # m loop
-        items = sorted(items, key=lambda x: x[1], reverse=True)  # n * log(n) loop
+        items = sorted(
+            items, key=lambda x: x[1], reverse=True
+        )  # n * log(n) loop
         key, value = items[0]
         result.append(key)
         items[0] = (key, value - 1)
@@ -75,16 +77,24 @@ def pick_max_steps_v3(items: Items) -> Result:
     O(n + m * log(n))
     Because of heapify in each iteration. Python's heapq.heapify() uses O(n) time.
     After that, heappop() and heappush() use O(log(n)) time.
+
+    Tie-breaking: when multiple items share the same value, the item that appeared
+    earlier in the input list is picked first, matching v1/v2 behavior.
+    The original index is kept in the heap tuple to preserve insertion order.
     """
     result = []
-    heap: list[tuple[float, str]] = [(-v, k) for k, v in items if v > 0]
+    # Include original index as secondary sort key so ties resolve by input order,
+    # matching the stable-sort behavior of v1 and the first-max behavior of v2.
+    heap: list[tuple[float, int, str]] = [
+        (-v, i, k) for i, (k, v) in enumerate(items) if v > 0
+    ]
     heapq.heapify(heap)  # n loop
     while heap:  # m loop
-        max_value, max_key = heapq.heappop(heap)  # log(n) loop
-        max_value = -max_value
+        neg_value, idx, max_key = heapq.heappop(heap)  # log(n) loop
+        max_value = -neg_value
         result.append(max_key)
         max_value -= 1
         if max_value > 0:
-            heapq.heappush(heap, (-max_value, max_key))  # log(n) loop
+            heapq.heappush(heap, (-max_value, idx, max_key))  # log(n) loop
 
     return result

--- a/packages/legacy/tests/test_pick_max_steps.py
+++ b/packages/legacy/tests/test_pick_max_steps.py
@@ -1,3 +1,5 @@
+import pytest
+
 from kitsuyui_ml.legacy.algorithms.pick_max_steps import (
     pick_max_steps_v1,
     pick_max_steps_v2,
@@ -84,3 +86,14 @@ def test_pick_sequence_v3() -> None:
     ]
     sequence = pick_max_steps_v3(items)
     assert sequence == tobe
+
+
+@pytest.mark.parametrize(
+    "fn",
+    [pick_max_steps_v1, pick_max_steps_v2, pick_max_steps_v3],
+)
+def test_tiebreak_preserves_input_order(fn):  # type: ignore[no-untyped-def]
+    """All three implementations must pick earlier-input item first on equal values."""
+    items = [("B", 1.0), ("A", 1.0)]
+    result = fn(items)
+    assert result == ["B", "A"], f"{fn.__name__} tiebreak differs: {result}"


### PR DESCRIPTION
## Summary

`pick_max_steps_v3` used a `(float, str)` heap tuple, causing items with equal float values to be ordered by **string lexicographic comparison** rather than their original input position. The sibling implementations `v1` (stable sort) and `v2` (first-max semantics) both preserve input order on ties, so the three functions were not equivalent for equal-value inputs.

## Change

Add the original insertion index as a secondary sort key — `(float, int, str)` — so equal float values resolve by input order, making all three implementations consistent.

## Example

```python
items = [("B", 1.0), ("A", 1.0)]
# Before: v3 returned ["A", "B"] (lexicographic)
# After:  v3 returns  ["B", "A"] (input order, matching v1/v2)
```

## Verification

- Added a parametrized test that asserts all three `pick_max_steps` variants agree when items have equal values.
- Existing tests continue to pass.
- `ruff format`, `ruff check`, and `mypy` pass.