### PR TITLE
fix: align PositionalEncoding2 dropout order

### DIFF
--- a/packages/torch_ext/src/kitsuyui_ml/torch_ext/positional_encoding.py
+++ b/packages/torch_ext/src/kitsuyui_ml/torch_ext/positional_encoding.py
@@ -80,11 +80,11 @@ class PositionalEncoding2(nn.Module):
         self.seq = nn.Sequential(
             OrderedDict(
                 [
-                    ("dropout", nn.Dropout(p=dropout)),
                     (
                         "pe",
                         RawPositionalEncoding(d_model, max_len),
                     ),
+                    ("dropout", nn.Dropout(p=dropout)),
                 ]
             )
         )

--- a/packages/torch_ext/tests/test_positional_encoding.py
+++ b/packages/torch_ext/tests/test_positional_encoding.py
@@ -31,8 +31,8 @@ PositionalEncoding(
         == """\
 PositionalEncoding2(
   (seq): Sequential(
-    (dropout): Dropout(p=0.0, inplace=False)
     (pe): RawPositionalEncoding()
+    (dropout): Dropout(p=0.0, inplace=False)
   )
 )"""
     )
@@ -43,6 +43,16 @@ PositionalEncoding2(
     y2 = pe2(x)
     # same result
     assert torch.allclose(y, y2, rtol=0.0, atol=0.0)
+
+
+def test_positional_encoding2_drops_positional_signal() -> None:
+    x = torch.ones(3, 2, 4)
+    pe = PositionalEncoding(d_model=4, dropout=1.0)
+    pe2 = PositionalEncoding2(d_model=4, dropout=1.0)
+
+    expected = torch.zeros_like(x)
+    assert torch.equal(pe(x), expected)
+    assert torch.equal(pe2(x), expected)
 
 
 def test_torch_jit_ready() -> None:


### PR DESCRIPTION
## Summary

`PositionalEncoding2` now applies positional encoding before dropout, matching `PositionalEncoding`'s `dropout(x + pe)` behavior. This prevents the positional signal from bypassing dropout in training mode.

## Change

- Reorder the `PositionalEncoding2` sequential module to run `RawPositionalEncoding` before `Dropout`.
- Update the repr expectation for the new module order.
- Add a regression test that uses `dropout=1.0` to verify both positional encoding implementations drop the positional signal.

## Verification

- `uv run python -m pytest packages/torch_ext/tests/test_positional_encoding.py`
- `uv run ruff format src/kitsuyui_ml/torch_ext/positional_encoding.py tests/test_positional_encoding.py --config ../dev-shared/ruff.toml`
- `uv run ruff check src/kitsuyui_ml/torch_ext/positional_encoding.py tests/test_positional_encoding.py --config ../dev-shared/ruff.toml`
- `uv run poe check`
- `uv run poe test`
- `git diff --check`
