### PR TITLE
fix: enforce abstract method in Animal by inheriting abc.ABC

### DIFF
--- a/packages/animal/src/kitsuyui_ml/animal/__init__.py
+++ b/packages/animal/src/kitsuyui_ml/animal/__init__.py
@@ -19,7 +19,7 @@ import abc
 from ._version import __version__
 
 
-class Animal:
+class Animal(abc.ABC):
     def __init__(self, name: str) -> None:
         self.name = name
 

--- a/packages/animal/tests/test_basis.py
+++ b/packages/animal/tests/test_basis.py
@@ -1,7 +1,14 @@
-from kitsuyui_ml.animal import Dog
+import pytest
+
+from kitsuyui_ml.animal import Animal, Dog
 
 
 def test_dog() -> None:
     dog = Dog("Pochi")
     assert dog.name == "Pochi"
     assert dog.speak() == "Bark"
+
+
+def test_animal_is_abstract() -> None:
+    with pytest.raises(TypeError):
+        Animal("test")  # type: ignore[abstract]


### PR DESCRIPTION
## Summary

`Animal` declared `@abc.abstractmethod` on `speak()` but did not inherit
from `abc.ABC`. Python only enforces abstract methods when `ABCMeta` is
active as the metaclass, so `Animal("x")` was silently allowed.

## Changes

- `class Animal:` → `class Animal(abc.ABC):` in `packages/animal/src/kitsuyui_ml/animal/__init__.py`
- Added `test_animal_is_abstract` in `tests/test_basis.py` to verify
  `Animal("test")` raises `TypeError`

## Verification

```
$ python -c "from kitsuyui_ml.animal import Animal; Animal('x')"
TypeError: Can't instantiate abstract class Animal without an implementation for abstract method 'speak'
```

All existing tests continue to pass.
