### PR TITLE
fix: remove undefined example from __all__ and docstring

### DIFF
--- a/packages/animal/src/kitsuyui_ml/animal/__init__.py
+++ b/packages/animal/src/kitsuyui_ml/animal/__init__.py
@@ -9,8 +9,6 @@ Example:
     >>> dog = kitsuyui.animal.Dog("Rex")
     >>> dog.speak()
     'Bark'
-    >>> kitsuyui.animal.example()
-    Bark
 """
 
 import abc
@@ -39,5 +37,4 @@ __all__ = [
     "Animal",
     "Dog",
     "__version__",
-    "example",
 ]


### PR DESCRIPTION
## Summary

- Removed `"example"` from `__all__` in `packages/animal/src/kitsuyui_ml/animal/__init__.py`
- Removed the `kitsuyui.animal.example()` call from the module docstring's Example section

## Why

`__all__` listed `"example"` but no `example` function is defined in the module. This caused:

1. `from kitsuyui_ml.animal import example` raises `ImportError` at import time.
2. The docstring's Example section showed `kitsuyui.animal.example()` as valid code, but executing it raises `AttributeError`.

Both the `__all__` entry and the docstring reference are removed to align the declared public API with the actual implementation.

## Changed files

- `packages/animal/src/kitsuyui_ml/animal/__init__.py` — removed `"example"` from `__all__` and from the docstring Example section

## Verification

All checks pass:

- `ruff check` — no issues
- `mypy` — no type errors
- `pytest` — all tests pass

## Trade-offs

Any caller that currently does `from kitsuyui_ml.animal import example` is already broken at runtime; removing the `__all__` entry makes the failure earlier and more explicit. There is no behavioral change for callers that do not reference `example`.
