### PR TITLE
Make build_vocab ordering explicit

### DIFF
--- a/packages/mini_vocab/src/kitsuyui_ml/mini_vocab/__init__.py
+++ b/packages/mini_vocab/src/kitsuyui_ml/mini_vocab/__init__.py
@@ -8,7 +8,6 @@ spacy Vocab is a good alternative. but not easy to use.
 from __future__ import annotations
 
 import dataclasses
-from collections import Counter
 from collections.abc import Callable, Iterable
 
 # https://packaging-guide.openastronomy.org/en/latest/advanced/versioning.html
@@ -67,14 +66,21 @@ def build_vocab(
     When `specials` is provided, it will be added to the vocabulary.
     This is useful for adding special tokens like
     `<unknown>`, `<pad>`, `<bos>`, and `<eos>`.
+    Vocabulary indices are deterministic: special tokens are inserted first
+    in the provided order, then regular tokens are inserted in first-seen
+    order across `texts`. Token frequency does not affect index assignment.
     """
-    counter: Counter[str] = Counter()
+    words: list[str] = []
+    seen_words: set[str] = set()
     for text in texts:
-        counter.update(tokenizer(text))
+        for word in tokenizer(text):
+            if word not in seen_words:
+                words.append(word)
+                seen_words.add(word)
     if specials is None:
         specials = []
     vocab = Vocab.create(words=specials)
-    vocab.add_words(counter.keys())
+    vocab.add_words(words)
     return vocab
 
 

--- a/packages/mini_vocab/tests/test_minivocab.py
+++ b/packages/mini_vocab/tests/test_minivocab.py
@@ -66,3 +66,23 @@ def test_build_vocab() -> None:
     assert vocab_no_specials.itos[3] == "of"
     assert vocab_no_specials.stoi["python"] == 4
     assert vocab_no_specials.itos[4] == "python"
+
+
+def test_build_vocab_uses_first_seen_order_not_frequency() -> None:
+    """
+    Test that build_vocab assigns indices by first-seen token order.
+    """
+    texts = [
+        "rare common common",
+        "common later",
+    ]
+
+    def simple_tokenizer(text: str) -> list[str]:
+        return text.split()
+
+    vocab = build_vocab(texts, simple_tokenizer, specials=["<pad>"])
+
+    assert vocab.stoi["<pad>"] == 0
+    assert vocab.stoi["rare"] == 1
+    assert vocab.stoi["common"] == 2
+    assert vocab.stoi["later"] == 3


### PR DESCRIPTION
## Summary
- Make the ordering contract in `build_vocab` explicit.
- Update tests to assert the intended ordering behavior directly.

## Verification
- `uv run pytest packages/mini_vocab/tests/test_minivocab.py`
- `uv run ruff check packages/mini_vocab/src packages/mini_vocab/tests`
- `uv run ruff format --check packages/mini_vocab/src/kitsuyui_ml/mini_vocab/__init__.py packages/mini_vocab/tests/test_minivocab.py --config packages/dev-shared/ruff.toml`
- `uv run poe check`
- `uv run poe test`
- `git diff --check`
