### PR TITLE
fix: use strict less-than in is_best_loss to prevent plateau stall

### DIFF
--- a/packages/legacy/src/kitsuyui_ml/legacy/early_stopping.py
+++ b/packages/legacy/src/kitsuyui_ml/legacy/early_stopping.py
@@ -31,12 +31,12 @@ class EarlyStopping:
             raise ValueError("Infinite loss: possible gradient explosion")
 
     def is_best_loss(self, loss: float) -> bool:
-        """Check if loss is better than current best loss."""
+        """Return True only when loss is strictly better than the current best."""
         self._validate_loss(loss)
         return self._is_best_loss_unchecked(loss)
 
     def _is_best_loss_unchecked(self, loss: float) -> bool:
-        return loss <= self._best_loss
+        return loss < self._best_loss
 
     def step(self, loss: float) -> None:
         """Update early stopping state."""

--- a/packages/legacy/tests/test_early_stopping.py
+++ b/packages/legacy/tests/test_early_stopping.py
@@ -6,8 +6,8 @@ from kitsuyui_ml.legacy.early_stopping import EarlyStopping
 def test_early_stopping() -> None:
     es = EarlyStopping(patience=3)
     assert not es.is_stopped()
-    assert not es(loss=1.0)  # improved, not stopped yet
-    assert es.is_best_loss(1.0)
+    assert not es(loss=1.0)  # improved (count reset), not stopped yet
+    assert not es.is_best_loss(1.0)  # equal loss is not strictly better
     assert not es.is_stopped()
     assert not es.is_best_loss(1.1)
     assert not es(loss=1.1)  # count=1, not stopped yet
@@ -15,6 +15,20 @@ def test_early_stopping() -> None:
     assert not es(loss=1.1)  # count=2, not stopped yet
     assert not es.is_stopped()
     assert es(loss=1.1)  # count=3 >= patience=3, stopped
+    assert es.is_stopped()
+
+
+def test_early_stopping_plateau() -> None:
+    """Repeated equal losses must count toward patience, not reset it."""
+    es = EarlyStopping(patience=3)
+    es(loss=1.0)  # best_loss = 1.0
+    assert not es.is_best_loss(1.0)  # equal is not strictly better
+    assert not es.is_stopped()
+    es.step(1.0)  # count = 1
+    assert not es.is_stopped()
+    es.step(1.0)  # count = 2
+    assert not es.is_stopped()
+    es.step(1.0)  # count = 3, patience exhausted
     assert es.is_stopped()
 
 


### PR DESCRIPTION
## Summary

`is_best_loss` used `loss <= self.best_loss`, so a flat loss curve (plateau)
continuously returned `True`: the `step()` method reset `count` to 0 on
every call, the patience counter never advanced, and training ran to the
maximum number of epochs.

The class docstring says "stop training when loss is not improving" — but
equal loss does not count as improvement, so the comparison should be strict.

## Change

- `is_best_loss`: change `<=` to `<`.
- Tests: update the assertion that checked `is_best_loss(x)` after calling
  `es(loss=x)` (equal loss is no longer "best").
- Add `test_early_stopping_plateau` to document the fixed behaviour: three
  consecutive equal losses with `patience=3` trigger `is_stopped()`.

## Verification

All 3 early-stopping tests pass.  Full test suite passes.
`ruff check` reports no issues.

## Trade-offs

`best_loss` is now only updated when the new loss is **strictly** smaller.
This means a first pass where loss happens to equal the initial `float("inf")`
would not update `best_loss` — but in practice all finite losses satisfy
`loss < inf`, so real training loops are unaffected.