### PR TITLE
Use strict best-loss comparison for epoch results

### DIFF
--- a/packages/legacy/src/kitsuyui_ml/legacy/epoch_result.py
+++ b/packages/legacy/src/kitsuyui_ml/legacy/epoch_result.py
@@ -31,4 +31,4 @@ class EpochResult:
         return self.end_valid - self.begin_train
 
     def is_best_loss(self) -> bool:
-        return self.valid_loss <= self.best_loss
+        return self.valid_loss < self.best_loss

--- a/packages/legacy/tests/test_epoch_result.py
+++ b/packages/legacy/tests/test_epoch_result.py
@@ -3,15 +3,19 @@ import datetime
 from kitsuyui_ml.legacy.epoch_result import EpochResult
 
 
-def test_epoch_result() -> None:
-    er = EpochResult(
+def make_epoch_result(
+    *,
+    valid_loss: float = 0.2,
+    best_loss: float = 0.2,
+) -> EpochResult:
+    return EpochResult(
         epoch=1,
         epochs=10,
         train_size=100,
         valid_size=50,
         train_loss=0.1,
-        valid_loss=0.2,
-        best_loss=0.2,
+        valid_loss=valid_loss,
+        best_loss=best_loss,
         early_stop_count=0,
         early_stop_patience=5,
         begin_train=datetime.datetime(2020, 1, 1, 0, 0, 0),
@@ -19,6 +23,10 @@ def test_epoch_result() -> None:
         begin_valid=datetime.datetime(2020, 1, 1, 0, 0, 1),
         end_valid=datetime.datetime(2020, 1, 1, 0, 0, 2),
     )
+
+
+def test_epoch_result() -> None:
+    er = make_epoch_result()
     assert er.epoch == 1
     assert er.epochs == 10
     assert er.train_size == 100
@@ -34,4 +42,8 @@ def test_epoch_result() -> None:
     assert er.valid_time == datetime.timedelta(seconds=1)
     assert er.total_time == datetime.timedelta(seconds=2)
 
-    assert er.is_best_loss()
+
+def test_epoch_result_is_best_loss_requires_improvement() -> None:
+    assert make_epoch_result(valid_loss=0.1, best_loss=0.2).is_best_loss()
+    assert not make_epoch_result(valid_loss=0.2, best_loss=0.2).is_best_loss()
+    assert not make_epoch_result(valid_loss=0.3, best_loss=0.2).is_best_loss()


### PR DESCRIPTION
## Summary
- Update `EpochResult.is_best_loss()` to require `valid_loss` to be lower than `best_loss`.
- Add better, equal, and worse boundary coverage for `EpochResult.is_best_loss()`.

## Changed files
- `packages/legacy/src/kitsuyui_ml/legacy/epoch_result.py`
- `packages/legacy/tests/test_epoch_result.py`

## Verification
- `uv run pytest packages/legacy/tests/test_epoch_result.py`
- `uv run ruff format --check packages/legacy/src/kitsuyui_ml/legacy/epoch_result.py packages/legacy/tests/test_epoch_result.py --config packages/dev-shared/ruff.toml`
- `uv run poe check`
- `uv run poe test`
- `uv run poe coverage`
- `uv run poe build`
- `actionlint`
- `typos`
- `./bin/check-generated-artifacts`
- `git diff --check`
