### PR TITLE
Limit lcm_cat sequence expansion

### DIFF
--- a/packages/torch_ext/src/kitsuyui_ml/torch_ext/lcm_cat.py
+++ b/packages/torch_ext/src/kitsuyui_ml/torch_ext/lcm_cat.py
@@ -4,12 +4,22 @@ import torch
 from torch import Tensor
 
 
-def lcm_cat(tensors: List[Tensor], batch_first: bool = False) -> Tensor:
+def lcm_cat(
+    tensors: List[Tensor],
+    batch_first: bool = False,
+    max_sequence_length: int = 4096,
+) -> Tensor:
     """lcm_cat
 
     Concatenate tensors after expanding the sequence length to the
     least common multiple of the sequence lengths in the batch.
+
+    Raises ValueError before expansion when the LCM sequence length
+    exceeds max_sequence_length.
     """
+    if max_sequence_length < 1:
+        raise ValueError("max_sequence_length must be positive")
+
     if batch_first:
         seq_dim = 1
     else:
@@ -22,6 +32,10 @@ def lcm_cat(tensors: List[Tensor], batch_first: bool = False) -> Tensor:
     for t in tensors:
         t_seq_size = torch.tensor(t.shape[seq_dim])
         torch.lcm(lcm_seq_size, t_seq_size, out=lcm_seq_size)
+        if int(lcm_seq_size) > max_sequence_length:
+            raise ValueError(
+                "lcm_cat sequence length exceeds max_sequence_length"
+            )
 
     # Repeat tensors to match the LCM
     for i, t in enumerate(tensors):

--- a/packages/torch_ext/tests/test_lcm_cat.py
+++ b/packages/torch_ext/tests/test_lcm_cat.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 
 from kitsuyui_ml.torch_ext.lcm_cat import lcm_cat
@@ -74,3 +75,47 @@ def test_lcm_cat_torch_jit_ready() -> None:
         batch_first=True,
     )
     assert asis.shape == (3, 2, 9)
+
+
+def test_lcm_cat_rejects_default_sequence_expansion_over_cap() -> None:
+    with pytest.raises(
+        ValueError,
+        match="lcm_cat sequence length exceeds max_sequence_length",
+    ):
+        lcm_cat(
+            [
+                torch.full((4097, 1, 1), 8),
+                torch.full((4099, 1, 1), 9),
+            ]
+        )
+
+
+def test_lcm_cat_allows_custom_sequence_cap() -> None:
+    asis = lcm_cat(
+        [
+            torch.full((4, 1, 1), 8),
+            torch.full((5, 1, 1), 9),
+        ],
+        max_sequence_length=20,
+    )
+    assert asis.shape == (20, 1, 2)
+
+
+def test_lcm_cat_rejects_non_positive_sequence_cap() -> None:
+    with pytest.raises(
+        ValueError,
+        match="max_sequence_length must be positive",
+    ):
+        lcm_cat([torch.full((2, 1, 1), 8)], max_sequence_length=0)
+
+
+def test_lcm_cat_torch_jit_rejects_sequence_expansion_over_cap() -> None:
+    lcm_cat_jit = torch.jit.script(lcm_cat)
+    with pytest.raises(torch.jit.Error, match="max_sequence_length"):
+        lcm_cat_jit(
+            [
+                torch.full((17, 1, 1), 8),
+                torch.full((19, 1, 1), 9),
+            ],
+            max_sequence_length=100,
+        )


### PR DESCRIPTION
## Summary
- Add a configurable `max_sequence_length` guard to `lcm_cat`
- Raise `ValueError` before repeat-based expansion would exceed the cap
- Add coverage for the default cap, a custom cap, and the TorchScript path

## Checks
- Generated artifacts check passed
- Focused lcm_cat pytest passed
- Package checks, tests, coverage, and diff check passed
- implement-validator: overall pass
