### PR TITLE
Bound pick_max_steps result expansion

### DIFF
--- a/packages/legacy/src/kitsuyui_ml/legacy/algorithms/pick_max_steps.py
+++ b/packages/legacy/src/kitsuyui_ml/legacy/algorithms/pick_max_steps.py
@@ -25,21 +25,54 @@ The result will be A, B, A, C, B, A, C, B, A, D, C, B, A, D
 """
 
 import heapq
+import math
 
 
 Items = list[tuple[str, float]]
 Result = list[str]
+DEFAULT_MAX_RESULT_LENGTH = 100_000
 
 
-def pick_max_steps_v1(items: Items) -> Result:
+def _validate_result_length(
+    items: Items,
+    max_result_length: int,
+) -> None:
+    if max_result_length < 0:
+        msg = "max_result_length must be greater than or equal to 0"
+        raise ValueError(msg)
+
+    result_length = 0
+    for _, value in items:
+        if not value > 0:
+            continue
+        if not math.isfinite(value):
+            msg = "pick_max_steps values must be finite"
+            raise ValueError(msg)
+
+        result_length += math.ceil(value)
+        if result_length > max_result_length:
+            msg = (
+                "pick_max_steps would produce more than "
+                f"{max_result_length} results"
+            )
+            raise ValueError(msg)
+
+
+def pick_max_steps_v1(
+    items: Items,
+    *,
+    max_result_length: int = DEFAULT_MAX_RESULT_LENGTH,
+) -> Result:
     """Most simple way to pick maximum value from given items.
 
     n is the number of items.
     m is the maximum value of items.
+    max_result_length limits the number of keys returned.
 
     O(m * n * log(n))
     Because of sorting in each iteration. Python's sort() and sorted() use Timsort algorithm. O(n * log(n))
     """
+    _validate_result_length(items, max_result_length)
     items = items[:]
     result = []
     while any(v > 0 for _, v in items):  # m loop
@@ -52,14 +85,20 @@ def pick_max_steps_v1(items: Items) -> Result:
     return result
 
 
-def pick_max_steps_v2(items: Items) -> Result:
+def pick_max_steps_v2(
+    items: Items,
+    *,
+    max_result_length: int = DEFAULT_MAX_RESULT_LENGTH,
+) -> Result:
     """Optimized way to pick maximum value from given items.
 
     n is the number of items.
     m is the maximum value of items.
+    max_result_length limits the number of keys returned.
 
     O(m * n)
     """
+    _validate_result_length(items, max_result_length)
     result = []
     while any(v > 0 for _, v in items):  # m loop
         max_key = max(items, key=lambda x: x[1])[0]  # n loop
@@ -68,11 +107,16 @@ def pick_max_steps_v2(items: Items) -> Result:
     return result
 
 
-def pick_max_steps_v3(items: Items) -> Result:
+def pick_max_steps_v3(
+    items: Items,
+    *,
+    max_result_length: int = DEFAULT_MAX_RESULT_LENGTH,
+) -> Result:
     """Optimized way to pick maximum value from given items.
 
     n is the number of items.
     m is the maximum value of items.
+    max_result_length limits the number of keys returned.
 
     O(n + m * log(n))
     Because of heapify in each iteration. Python's heapq.heapify() uses O(n) time.
@@ -82,6 +126,7 @@ def pick_max_steps_v3(items: Items) -> Result:
     earlier in the input list is picked first, matching v1/v2 behavior.
     The original index is kept in the heap tuple to preserve insertion order.
     """
+    _validate_result_length(items, max_result_length)
     result = []
     # Include original index as secondary sort key so ties resolve by input order,
     # matching the stable-sort behavior of v1 and the first-max behavior of v2.

--- a/packages/legacy/tests/test_pick_max_steps.py
+++ b/packages/legacy/tests/test_pick_max_steps.py
@@ -1,6 +1,7 @@
 import pytest
 
 from kitsuyui_ml.legacy.algorithms.pick_max_steps import (
+    DEFAULT_MAX_RESULT_LENGTH,
     pick_max_steps_v1,
     pick_max_steps_v2,
     pick_max_steps_v3,
@@ -97,3 +98,30 @@ def test_tiebreak_preserves_input_order(fn):  # type: ignore[no-untyped-def]
     items = [("B", 1.0), ("A", 1.0)]
     result = fn(items)
     assert result == ["B", "A"], f"{fn.__name__} tiebreak differs: {result}"
+
+
+@pytest.mark.parametrize(
+    "fn",
+    [pick_max_steps_v1, pick_max_steps_v2, pick_max_steps_v3],
+)
+def test_rejects_results_over_default_limit(fn):  # type: ignore[no-untyped-def]
+    with pytest.raises(ValueError, match="more than"):
+        fn([("A", DEFAULT_MAX_RESULT_LENGTH + 1.0)])
+
+
+@pytest.mark.parametrize(
+    "fn",
+    [pick_max_steps_v1, pick_max_steps_v2, pick_max_steps_v3],
+)
+def test_rejects_results_over_custom_limit(fn):  # type: ignore[no-untyped-def]
+    with pytest.raises(ValueError, match="more than"):
+        fn([("A", 3.1)], max_result_length=3)
+
+
+@pytest.mark.parametrize(
+    "fn",
+    [pick_max_steps_v1, pick_max_steps_v2, pick_max_steps_v3],
+)
+def test_rejects_infinite_positive_values(fn):  # type: ignore[no-untyped-def]
+    with pytest.raises(ValueError, match="finite"):
+        fn([("A", float("inf"))])


### PR DESCRIPTION
## Summary

- Add a shared preflight check that estimates the number of keys `pick_max_steps_*` would return before building the result list.
- Reject positive infinite values and inputs that exceed the configured result length.
- Cover the default limit, a caller-provided lower limit, and existing ordering behavior for all three implementations.

## Changed files

- `packages/legacy/src/kitsuyui_ml/legacy/algorithms/pick_max_steps.py`
- `packages/legacy/tests/test_pick_max_steps.py`

## Verification

- `uv run --with ruff ruff format packages/legacy/src/kitsuyui_ml/legacy/algorithms/pick_max_steps.py packages/legacy/tests/test_pick_max_steps.py --config packages/dev-shared/ruff.toml`
- `PYTHONPATH=packages/legacy/src uv run --with pytest pytest packages/legacy/tests/test_pick_max_steps.py`
- `uv run --with ruff ruff check src/kitsuyui_ml/legacy/algorithms/pick_max_steps.py tests/test_pick_max_steps.py --config ../dev-shared/ruff.toml` from `packages/legacy`
- `env MYPYPATH=packages/legacy/src uv run --with mypy --with pytest mypy --namespace-packages --explicit-package-bases packages/legacy/src/kitsuyui_ml/legacy/algorithms/pick_max_steps.py packages/legacy/tests/test_pick_max_steps.py`
- `uv run poe check`
- `uv run poe test`
- `uv run poe coverage`
- `uv run poe build`
- `./bin/check-generated-artifacts`
- `uvx typos packages/legacy/src/kitsuyui_ml/legacy/algorithms/pick_max_steps.py packages/legacy/tests/test_pick_max_steps.py README.md`
- `uvx vulture packages/legacy/src/kitsuyui_ml/legacy/algorithms/pick_max_steps.py packages/legacy/tests/test_pick_max_steps.py`
- `git diff --check`

## Trade-off

- The default limit is intentionally conservative for this sample algorithm. Callers that need larger sequences can pass a larger `max_result_length` explicitly.
