### PR TITLE
Bound mini_vocab size growth

### DIFF
--- a/packages/mini_vocab/src/kitsuyui_ml/mini_vocab/__init__.py
+++ b/packages/mini_vocab/src/kitsuyui_ml/mini_vocab/__init__.py
@@ -21,12 +21,16 @@ class Vocab:
     but does not depend on torch and torchtext.
     """
 
-    __slots__ = ("_current_index", "_itos", "_stoi")
+    __slots__ = ("_current_index", "_itos", "_max_size", "_stoi")
 
-    def __init__(self) -> None:
+    def __init__(self, *, max_size: int | None = None) -> None:
+        if max_size is not None and max_size < 0:
+            msg = "max_size must be non-negative"
+            raise ValueError(msg)
         self._stoi: dict[str, int] = {}
         self._itos: dict[int, str] = {}
         self._current_index: int = 0
+        self._max_size = max_size
 
     @property
     def stoi(self) -> MappingProxyType[str, int]:
@@ -44,10 +48,14 @@ class Vocab:
         """
         Add a single word to the vocabulary.
         """
-        if word not in self._stoi:
-            self._stoi[word] = self._current_index
-            self._itos[self._current_index] = word
-            self._current_index += 1
+        if word in self._stoi:
+            return
+        if self._max_size is not None and len(self._stoi) >= self._max_size:
+            msg = "max_size exceeded"
+            raise ValueError(msg)
+        self._stoi[word] = self._current_index
+        self._itos[self._current_index] = word
+        self._current_index += 1
 
     def add_words(self, words: Iterable[str]) -> None:
         """
@@ -60,11 +68,13 @@ class Vocab:
         return len(self._stoi)
 
     @classmethod
-    def create(cls, words: Iterable[str]) -> Vocab:
+    def create(
+        cls, words: Iterable[str], *, max_size: int | None = None
+    ) -> Vocab:
         """
         Create a vocabulary from a list of words.
         """
-        vocab = cls()
+        vocab = cls(max_size=max_size)
         vocab.add_words(words)
         return vocab
 
@@ -74,6 +84,7 @@ def build_vocab(
     tokenizer: Callable[[str], list[str]],
     *,
     specials: list[str] | None = None,
+    max_size: int | None = None,
 ) -> Vocab:
     """
     Build a vocabulary from a list of texts using a tokenizer.
@@ -83,18 +94,13 @@ def build_vocab(
     Vocabulary indices are deterministic: special tokens are inserted first
     in the provided order, then regular tokens are inserted in first-seen
     order across `texts`. Token frequency does not affect index assignment.
+    `max_size` limits the number of unique tokens in the vocabulary.
     """
-    words: list[str] = []
-    seen_words: set[str] = set()
+    vocab = Vocab(max_size=max_size)
+    if specials is not None:
+        vocab.add_words(specials)
     for text in texts:
-        for word in tokenizer(text):
-            if word not in seen_words:
-                words.append(word)
-                seen_words.add(word)
-    if specials is None:
-        specials = []
-    vocab = Vocab.create(words=specials)
-    vocab.add_words(words)
+        vocab.add_words(tokenizer(text))
     return vocab
 
 

--- a/packages/mini_vocab/tests/test_minivocab.py
+++ b/packages/mini_vocab/tests/test_minivocab.py
@@ -1,3 +1,5 @@
+import pytest
+
 from kitsuyui_ml.mini_vocab import Vocab, build_vocab
 
 
@@ -86,3 +88,50 @@ def test_build_vocab_uses_first_seen_order_not_frequency() -> None:
     assert vocab.stoi["rare"] == 1
     assert vocab.stoi["common"] == 2
     assert vocab.stoi["later"] == 3
+
+
+def test_vocab_max_size_limits_unique_words() -> None:
+    """
+    Test that max_size rejects new unique words after the bound is reached.
+    """
+    vocab = Vocab.create(["hello", "world"], max_size=2)
+
+    vocab.add_word("hello")
+
+    assert len(vocab) == 2
+    with pytest.raises(ValueError, match="max_size exceeded"):
+        vocab.add_word("again")
+
+
+def test_vocab_rejects_negative_max_size() -> None:
+    """
+    Test that negative max_size is rejected before adding words.
+    """
+    with pytest.raises(ValueError, match="max_size must be non-negative"):
+        Vocab(max_size=-1)
+
+
+def test_build_vocab_max_size_limits_tokens_and_specials() -> None:
+    """
+    Test that build_vocab applies max_size to specials and regular tokens.
+    """
+    texts = [
+        "rare common common",
+        "common later",
+    ]
+
+    def simple_tokenizer(text: str) -> list[str]:
+        return text.split()
+
+    vocab = build_vocab(
+        texts, simple_tokenizer, specials=["<pad>"], max_size=4
+    )
+
+    assert len(vocab) == 4
+    assert vocab.stoi["<pad>"] == 0
+    assert vocab.stoi["rare"] == 1
+    assert vocab.stoi["common"] == 2
+    assert vocab.stoi["later"] == 3
+
+    with pytest.raises(ValueError, match="max_size exceeded"):
+        build_vocab(texts, simple_tokenizer, specials=["<pad>"], max_size=3)


### PR DESCRIPTION
## Summary
- Add an optional `max_size` bound to `Vocab` and `build_vocab` so callers can cap unique vocabulary entries.
- Reject negative bounds before population and raise when a new unique token would exceed the configured bound.
- Preserve first-seen token ordering, duplicate-token no-op behavior, and the current `__slots__`-based `Vocab` layout.

## Changed files
- `packages/mini_vocab/src/kitsuyui_ml/mini_vocab/__init__.py`
- `packages/mini_vocab/tests/test_minivocab.py`

## Verification
- `./bin/check-generated-artifacts`
- `uv sync`
- `uv run poe check`
- `uv run poe test`
- `uv run poe coverage`
