### PR TITLE
fix: correct module name in animal package docstring

### DIFF
--- a/packages/animal/src/kitsuyui_ml/animal/__init__.py
+++ b/packages/animal/src/kitsuyui_ml/animal/__init__.py
@@ -5,8 +5,8 @@ and a `Dog` subclass to represent animals.
 This package is just for example.
 
 Example:
-    >>> import kitsuyui.animal
-    >>> dog = kitsuyui.animal.Dog("Rex")
+    >>> import kitsuyui_ml.animal
+    >>> dog = kitsuyui_ml.animal.Dog("Rex")
     >>> dog.speak()
     'Bark'
 """


### PR DESCRIPTION
## Summary

The module-level docstring in `packages/animal/src/kitsuyui_ml/animal/__init__.py`
referenced `kitsuyui.animal` as the import path, but the actual module is
`kitsuyui_ml.animal`. Following the example as written would cause an
`ImportError` because the `kitsuyui.animal` package does not exist.

## Changes

- `import kitsuyui.animal` → `import kitsuyui_ml.animal`
- `kitsuyui.animal.Dog("Rex")` → `kitsuyui_ml.animal.Dog("Rex")`

## Verification

- `uv run poe check`: all checks passed (ruff + mypy)
- `uv run poe test`: 2/2 tests pass
- `vulture`: 0 findings
