### PR TITLE
fix(EpochResult): reject naive datetimes to prevent silent incorrect elapsed time

### DIFF
--- a/packages/legacy/src/kitsuyui_ml/legacy/epoch_result.py
+++ b/packages/legacy/src/kitsuyui_ml/legacy/epoch_result.py
@@ -18,6 +18,20 @@ class EpochResult:
     begin_valid: datetime.datetime
     end_valid: datetime.datetime
 
+    def __post_init__(self) -> None:
+        for field_name in (
+            "begin_train",
+            "end_train",
+            "begin_valid",
+            "end_valid",
+        ):
+            value: datetime.datetime = getattr(self, field_name)
+            if value.tzinfo is None:
+                raise ValueError(
+                    f"{field_name} must be timezone-aware; got naive datetime. "
+                    "Use datetime.now(tz=datetime.timezone.utc) or attach tzinfo."
+                )
+
     @property
     def train_time(self) -> datetime.timedelta:
         return self.end_train - self.begin_train

--- a/packages/legacy/tests/test_epoch_result.py
+++ b/packages/legacy/tests/test_epoch_result.py
@@ -1,6 +1,10 @@
 import datetime
 
+import pytest
+
 from kitsuyui_ml.legacy.epoch_result import EpochResult
+
+_UTC = datetime.timezone.utc
 
 
 def make_epoch_result(
@@ -18,10 +22,10 @@ def make_epoch_result(
         best_loss=best_loss,
         early_stop_count=0,
         early_stop_patience=5,
-        begin_train=datetime.datetime(2020, 1, 1, 0, 0, 0),
-        end_train=datetime.datetime(2020, 1, 1, 0, 0, 1),
-        begin_valid=datetime.datetime(2020, 1, 1, 0, 0, 1),
-        end_valid=datetime.datetime(2020, 1, 1, 0, 0, 2),
+        begin_train=datetime.datetime(2020, 1, 1, 0, 0, 0, tzinfo=_UTC),
+        end_train=datetime.datetime(2020, 1, 1, 0, 0, 1, tzinfo=_UTC),
+        begin_valid=datetime.datetime(2020, 1, 1, 0, 0, 1, tzinfo=_UTC),
+        end_valid=datetime.datetime(2020, 1, 1, 0, 0, 2, tzinfo=_UTC),
     )
 
 
@@ -36,7 +40,9 @@ def test_epoch_result() -> None:
     assert er.best_loss == 0.2
     assert er.early_stop_count == 0
     assert er.early_stop_patience == 5
-    assert er.begin_train == datetime.datetime(2020, 1, 1, 0, 0, 0)
+    assert er.begin_train == datetime.datetime(
+        2020, 1, 1, 0, 0, 0, tzinfo=_UTC
+    )
 
     assert er.train_time == datetime.timedelta(seconds=1)
     assert er.valid_time == datetime.timedelta(seconds=1)
@@ -47,3 +53,35 @@ def test_epoch_result_is_best_loss_requires_improvement() -> None:
     assert make_epoch_result(valid_loss=0.1, best_loss=0.2).is_best_loss()
     assert not make_epoch_result(valid_loss=0.2, best_loss=0.2).is_best_loss()
     assert not make_epoch_result(valid_loss=0.3, best_loss=0.2).is_best_loss()
+
+
+def _make_with_override(field: str, value: datetime.datetime) -> EpochResult:
+    defaults = {
+        "begin_train": datetime.datetime(2020, 1, 1, 0, 0, 0, tzinfo=_UTC),
+        "end_train": datetime.datetime(2020, 1, 1, 0, 0, 1, tzinfo=_UTC),
+        "begin_valid": datetime.datetime(2020, 1, 1, 0, 0, 1, tzinfo=_UTC),
+        "end_valid": datetime.datetime(2020, 1, 1, 0, 0, 2, tzinfo=_UTC),
+    }
+    defaults[field] = value
+    return EpochResult(
+        epoch=1,
+        epochs=10,
+        train_size=100,
+        valid_size=50,
+        train_loss=0.1,
+        valid_loss=0.2,
+        best_loss=0.2,
+        early_stop_count=0,
+        early_stop_patience=5,
+        begin_train=defaults["begin_train"],
+        end_train=defaults["end_train"],
+        begin_valid=defaults["begin_valid"],
+        end_valid=defaults["end_valid"],
+    )
+
+
+def test_epoch_result_rejects_naive_datetime() -> None:
+    naive = datetime.datetime(2020, 1, 1, 0, 0, 0)
+    for field in ("begin_train", "end_train", "begin_valid", "end_valid"):
+        with pytest.raises(ValueError, match="timezone-aware"):
+            _make_with_override(field, naive)


### PR DESCRIPTION
## Summary

`EpochResult` accepted naive `datetime.datetime` values for its four timestamp fields
(`begin_train`, `end_train`, `begin_valid`, `end_valid`). This caused two problems:

- Mixing a naive and an aware datetime raises `TypeError` when accessing `train_time`,
  `valid_time`, or `total_time` — detected only at runtime, not at construction.
- Mixing naive datetimes from different local timezones (e.g. UTC and JST) silently
  produces elapsed-time values that are off by up to ±14 hours.

## Changes

- **`epoch_result.py`**: add `__post_init__` that raises `ValueError` on construction
  when any timestamp field is a naive datetime (`tzinfo is None`).
- **`test_epoch_result.py`**: update existing tests to pass timezone-aware datetimes
  (`datetime.timezone.utc`); add `test_epoch_result_rejects_naive_datetime` that
  asserts all four fields individually reject naive datetimes.

## Verification

- `uv run poe test` — all tests pass
- `uv run poe check` — ruff + mypy clean
- vulture (via audit-toolchain) — 0 findings
