### PR TITLE
Pass run-each subcommands as argv

### DIFF
--- a/bin/run-each
+++ b/bin/run-each
@@ -6,9 +6,17 @@ shift
 
 # Use xargs instead find -exec to pass exit status.
 
+# shellcheck disable=SC2016
 find packages \
 -type d \
 -not -path 'packages/dev-shared' \
 -maxdepth 1 \
 -mindepth 1 \
-| xargs -P 1 -n 1 -I {} sh -c "cd '{}' && uv run poe $subcommand"
+-print0 \
+| xargs -0 -P 1 -I {} sh -c '
+package_dir=$1
+shift
+
+cd "$package_dir"
+uv run poe "$@"
+' sh {} "$subcommand" "$@"

--- a/packages/hello/tests/test_run_each.py
+++ b/packages/hello/tests/test_run_each.py
@@ -1,0 +1,42 @@
+import os
+import subprocess
+from pathlib import Path
+
+
+def test_run_each_passes_subcommand_as_literal_argument(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    workspace = tmp_path / "workspace"
+    package_dir = workspace / "packages" / "sample"
+    dev_shared_dir = workspace / "packages" / "dev-shared"
+    fake_bin_dir = tmp_path / "bin"
+    fake_uv = fake_bin_dir / "uv"
+    argv_log = tmp_path / "uv-argv.log"
+
+    package_dir.mkdir(parents=True)
+    dev_shared_dir.mkdir(parents=True)
+    fake_bin_dir.mkdir()
+    fake_uv.write_text(
+        "#!/usr/bin/env sh\n"
+        "set -eu\n"
+        "printf '%s\\n' \"$@\" >> \"$UV_ARGV_LOG\"\n",
+        encoding="utf-8",
+    )
+    fake_uv.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin_dir}{os.pathsep}{env['PATH']}"
+    env["UV_ARGV_LOG"] = str(argv_log)
+
+    subprocess.run(  # noqa: S603
+        [str(repo_root / "bin" / "run-each"), "safe; touch pwned"],
+        cwd=workspace,
+        env=env,
+        check=True,
+    )
+
+    assert not (workspace / "pwned").exists()
+    assert argv_log.read_text(encoding="utf-8").splitlines() == [
+        "run",
+        "poe",
+        "safe; touch pwned",
+    ]


### PR DESCRIPTION
Summary:
- Pass the run-each package directory and poe task through sh -c positional arguments instead of interpolating the task into the shell source.
- Preserve package iteration while keeping packages/dev-shared excluded.
- Add regression coverage for shell metacharacters in task names.

Changed files:
- `bin/run-each`
- `packages/hello/tests/test_run_each.py`

Tests:
- `bash -n bin/run-each`
- `shellcheck bin/run-each`
- `./bin/check-generated-artifacts`
- `uv sync`
- `uv run pytest tests/test_run_each.py` from `packages/hello`
- `./bin/run-each test`
- `uv run poe check`
- `uv run poe coverage`
- `git diff --check`
