### PR TITLE
Document legacy package lifecycle

### DIFF
--- a/packages/legacy/README.md
+++ b/packages/legacy/README.md
@@ -2,7 +2,29 @@
 
 ## What is this?
 
-- This package is an example.
+This package keeps older playground examples that still need runnable test
+coverage while their long-term home is undecided.
+
+It is not a stable public API. If an example becomes useful outside this
+playground, move it into a non-legacy package under `packages/` before new
+callers depend on it.
+
+## Lifecycle
+
+`kitsuyui_ml.legacy` is intentionally retained until each module has one of the
+following outcomes:
+
+- It is moved to a non-legacy package with matching tests and documentation.
+- It remains here as a runnable example because no supported package needs it.
+- It is removed after no tests, notebooks, or package code depend on it.
+
+A module is ready to leave this package when the replacement or removal PR
+records the chosen destination, keeps the relevant examples covered by tests,
+and updates any notebooks or README references that still point here.
+
+There is no scheduled package-wide removal date. Treat this package as a
+holding area for examples to migrate or delete module by module, not as a place
+for new reusable APIs.
 
 # LICENSE
 

--- a/packages/legacy/pyproject.toml
+++ b/packages/legacy/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "kitsuyui_ml.legacy"
 dynamic = ["version"]
-description = "A playground for publishing packages to PyPI"
+description = "Legacy playground examples retained until each module is migrated or removed"
 # https://scientific-python.org/specs/spec-0000/
 requires-python = ">=3.12"
 readme = { file = "README.md", content-type = "text/markdown" }
@@ -38,7 +38,8 @@ dependencies = [
     "graphviz",
 ]
 [project.urls]
-Homepage = "https://github.com/kitsuyui/pypi-playground"
+Homepage = "https://github.com/kitsuyui/ml-playground/tree/main/packages/legacy"
+Repository = "https://github.com/kitsuyui/ml-playground"
 
 [build-system]
 requires = ["setuptools", "setuptools_scm"]


### PR DESCRIPTION
## Summary
- Clarify that `kitsuyui_ml.legacy` is retained as a runnable example holding area, not a stable public API.
- Document the module-level outcomes for keeping, moving, or removing legacy examples.
- Update package metadata so the description and links point to the current package lifecycle context.

## Changed files
- `packages/legacy/README.md`
- `packages/legacy/pyproject.toml`

## Verification
- `uv run poe build`
- `uv run poe check`
- `uv run poe test`
- `uv run poe coverage`
- `uv run poe check` in `packages/legacy`
- `uv run poe test` in `packages/legacy`
- `typos packages/legacy/README.md packages/legacy/pyproject.toml`
- `./bin/check-generated-artifacts`
- `actionlint`
- `git diff --check`
