### PR TITLE
docs: clarify pick_max_steps reference implementations and add cross-equivalence tests

### DIFF
--- a/packages/legacy/src/kitsuyui_ml/legacy/algorithms/pick_max_steps.py
+++ b/packages/legacy/src/kitsuyui_ml/legacy/algorithms/pick_max_steps.py
@@ -63,7 +63,15 @@ def pick_max_steps_v1(
     *,
     max_result_length: int = DEFAULT_MAX_RESULT_LENGTH,
 ) -> Result:
-    """Most simple way to pick maximum value from given items.
+    """Reference implementation using full sort per iteration.
+
+    Retained for educational comparison only. Prefer pick_max_steps_v3 for
+    production use.
+
+    Tie-breaking note: when items that start distinct become equal mid-run, this
+    implementation picks whichever item is first in the *current* sorted list,
+    which drifts from original input order. v2 and v3 always resolve ties by
+    original input order, so they can diverge from this implementation.
 
     n is the number of items.
     m is the maximum value of items.
@@ -90,7 +98,10 @@ def pick_max_steps_v2(
     *,
     max_result_length: int = DEFAULT_MAX_RESULT_LENGTH,
 ) -> Result:
-    """Optimized way to pick maximum value from given items.
+    """Reference implementation using linear scan per iteration.
+
+    Retained for educational comparison only. Prefer pick_max_steps_v3 for
+    production use.
 
     n is the number of items.
     m is the maximum value of items.

--- a/packages/legacy/tests/test_pick_max_steps.py
+++ b/packages/legacy/tests/test_pick_max_steps.py
@@ -125,3 +125,41 @@ def test_rejects_results_over_custom_limit(fn):  # type: ignore[no-untyped-def]
 def test_rejects_infinite_positive_values(fn):  # type: ignore[no-untyped-def]
     with pytest.raises(ValueError, match="finite"):
         fn([("A", float("inf"))])
+
+
+@pytest.mark.parametrize(
+    "items",
+    [
+        [("A", 4.2), ("B", 3.5), ("C", 2.8), ("D", 1.1)],
+        [("X", 1.0), ("Y", 1.0)],
+        [("Z", 3.0)],
+    ],
+)
+def test_all_versions_produce_identical_output(items):  # type: ignore[no-untyped-def]
+    """v1, v2, and v3 must return the same sequence for inputs without mid-run ties."""
+    r1 = pick_max_steps_v1(items)
+    r2 = pick_max_steps_v2(items)
+    r3 = pick_max_steps_v3(items)
+    assert r1 == r3, f"v1 and v3 differ: {r1!r} != {r3!r}"
+    assert r2 == r3, f"v2 and v3 differ: {r2!r} != {r3!r}"
+
+
+def test_v1_tie_break_diverges_from_v2_v3_on_mid_run_ties() -> None:
+    """v1 uses evolving list-order tie-breaking; v2 and v3 use original input order.
+
+    When items that start with distinct values become equal mid-run, v1 picks
+    whichever item happens to be earliest in the *current* (sorted) list, which
+    drifts from original input order. v2/v3 always prefer the item that appeared
+    first in the original input, so they agree with each other but not with v1.
+
+    Example: [A=2, B=2, C=1]
+      v1 → [A, B, B, A, C]  (after B is updated to 1, it precedes A in sorted order)
+      v2 → [A, B, A, B, C]  (first-max always resolves to original insertion order)
+      v3 → [A, B, A, B, C]  (heap stores original index; ties resolve by insertion order)
+    """
+    items = [("A", 2.0), ("B", 2.0), ("C", 1.0)]
+    r1 = pick_max_steps_v1(items)
+    r2 = pick_max_steps_v2(items)
+    r3 = pick_max_steps_v3(items)
+    assert r2 == r3, f"v2 and v3 must agree: {r2!r} != {r3!r}"
+    assert r1 != r3, "v1 is expected to diverge from v3 on mid-run ties"


### PR DESCRIPTION
## Summary

Three implementations of `pick_max_steps` (v1, v2, v3) coexist in
`packages/legacy/src/kitsuyui_ml/legacy/algorithms/pick_max_steps.py`
without any indication that v1/v2 are retained only for educational comparison.
This change makes the intent explicit and adds cross-equivalence tests.

## Changes

- **`pick_max_steps.py`**: Updated docstrings for v1 and v2 to state they are
  reference implementations kept for educational comparison; prefer v3 for
  production use. Added a tie-breaking note to v1 documenting a subtle
  behavioral difference (see below).

- **`test_pick_max_steps.py`**: Added two new tests:
  - `test_all_versions_produce_identical_output` — parametrized over inputs
    without mid-run ties; verifies v1/v2/v3 agree.
  - `test_v1_tie_break_diverges_from_v2_v3_on_mid_run_ties` — documents the
    known divergence case and pins the expected behavior.

## Discovered behavioral difference in v1

While writing cross-equivalence tests, a real divergence was found between v1
and v2/v3 on inputs where distinct values become equal mid-run:

```
Input: [A=2.0, B=2.0, C=1.0]
v1 → [A, B, B, A, C]   (tie resolved by current sorted-list position)
v2 → [A, B, A, B, C]   (tie resolved by original input order)
v3 → [A, B, A, B, C]   (tie resolved by original input order via heap index)
```

v1's sort-based approach mutates list order after each iteration, so ties
encountered mid-run favor the item at the front of the *current* list rather
than the original input. v2 and v3 consistently prefer original input order.
This difference is now documented in v1's docstring and in a dedicated test.

## Verification

- `poe check`: all checks passed
- `poe test`: 77 passed (legacy package)
