### PR TITLE
deprecate: mark ScaleEmbedding2 and PositionalEncoding2 as deprecated

### DIFF
--- a/packages/torch_ext/src/kitsuyui_ml/torch_ext/positional_encoding.py
+++ b/packages/torch_ext/src/kitsuyui_ml/torch_ext/positional_encoding.py
@@ -1,4 +1,5 @@
 import math
+import warnings
 from typing import OrderedDict
 
 import torch
@@ -43,7 +44,10 @@ class PositionalEncoding(nn.Module):
 
 
 class RawPositionalEncoding(nn.Module):
-    """PositionalEncoding without the dropout layer."""
+    """PositionalEncoding without the dropout layer.
+
+    Internal building block used by PositionalEncoding2.
+    """
 
     def __init__(
         self,
@@ -70,12 +74,23 @@ class RawPositionalEncoding(nn.Module):
 
 
 class PositionalEncoding2(nn.Module):
+    """Deprecated. Use PositionalEncoding instead.
+
+    PositionalEncoding2 is equivalent to PositionalEncoding and will be removed in a future version.
+    """
+
     def __init__(
         self,
         d_model: int,
         dropout: float = 0.1,
         max_len: int = 5000,
     ):
+        warnings.warn(
+            "PositionalEncoding2 is deprecated and equivalent to PositionalEncoding. "
+            "Use PositionalEncoding instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         super().__init__()
         self.seq = nn.Sequential(
             OrderedDict(

--- a/packages/torch_ext/src/kitsuyui_ml/torch_ext/scale_embedding.py
+++ b/packages/torch_ext/src/kitsuyui_ml/torch_ext/scale_embedding.py
@@ -1,3 +1,5 @@
+import warnings
+
 import torch
 import torch.nn as nn
 from torch import Tensor
@@ -23,13 +25,22 @@ class ScaleEmbedding(nn.Module):
 
 
 class ScaleEmbedding2(nn.Module):
-    """ScaleEmbedding"""
+    """Deprecated. Use ScaleEmbedding instead.
+
+    ScaleEmbedding2 is identical to ScaleEmbedding and will be removed in a future version.
+    """
 
     def __init__(
         self,
         num_embeddings: int,
         embedding_dim: int,
     ) -> None:
+        warnings.warn(
+            "ScaleEmbedding2 is deprecated and identical to ScaleEmbedding. "
+            "Use ScaleEmbedding instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         super().__init__()
         self.embedding = nn.Embedding(
             num_embeddings=num_embeddings,

--- a/packages/torch_ext/tests/test_positional_encoding.py
+++ b/packages/torch_ext/tests/test_positional_encoding.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 
 from kitsuyui_ml.torch_ext.positional_encoding import (
@@ -25,7 +26,10 @@ PositionalEncoding(
   (dropout): Dropout(p=0.0, inplace=False)
 )"""
     )
-    pe2 = PositionalEncoding2(d_model=4, dropout=0.0)
+    with pytest.warns(
+        DeprecationWarning, match="PositionalEncoding2 is deprecated"
+    ):
+        pe2 = PositionalEncoding2(d_model=4, dropout=0.0)
     assert (
         repr(pe2)
         == """\
@@ -48,7 +52,10 @@ PositionalEncoding2(
 def test_positional_encoding2_drops_positional_signal() -> None:
     x = torch.ones(3, 2, 4)
     pe = PositionalEncoding(d_model=4, dropout=1.0)
-    pe2 = PositionalEncoding2(d_model=4, dropout=1.0)
+    with pytest.warns(
+        DeprecationWarning, match="PositionalEncoding2 is deprecated"
+    ):
+        pe2 = PositionalEncoding2(d_model=4, dropout=1.0)
 
     expected = torch.zeros_like(x)
     assert torch.equal(pe(x), expected)
@@ -66,7 +73,10 @@ def test_torch_jit_ready() -> None:
     assert y.shape == (4, 1, 4)
     assert pe_jit.code is not None
 
-    pe2 = PositionalEncoding2(d_model=4, dropout=0.0)
+    with pytest.warns(
+        DeprecationWarning, match="PositionalEncoding2 is deprecated"
+    ):
+        pe2 = PositionalEncoding2(d_model=4, dropout=0.0)
     pe2_jit = torch.jit.script(pe2)
     y2 = pe2_jit(x)
     assert y2.shape == (4, 1, 4)

--- a/packages/torch_ext/tests/test_scale_embedding.py
+++ b/packages/torch_ext/tests/test_scale_embedding.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 
 from kitsuyui_ml.torch_ext.scale_embedding import (
@@ -23,7 +24,10 @@ def test_scale_embedding() -> None:
     assert se.scale.dtype == torch.float64
 
     # Test 2
-    se2 = ScaleEmbedding2(num_embeddings, embedding_dim)
+    with pytest.warns(
+        DeprecationWarning, match="ScaleEmbedding2 is deprecated"
+    ):
+        se2 = ScaleEmbedding2(num_embeddings, embedding_dim)
     y2 = se2(x)
     assert y2.shape == y.shape
 
@@ -40,7 +44,10 @@ def test_torch_jit_ready() -> None:
     assert y.shape == (200, 100)
     assert se_jit.code is not None
 
-    se2 = ScaleEmbedding2(num_embeddings, embedding_dim)
+    with pytest.warns(
+        DeprecationWarning, match="ScaleEmbedding2 is deprecated"
+    ):
+        se2 = ScaleEmbedding2(num_embeddings, embedding_dim)
     se2_jit = torch.jit.script(se2)
     y2 = se2_jit(x)
     assert y2.shape == (200, 100)


### PR DESCRIPTION
## Summary

`ScaleEmbedding2` and `PositionalEncoding2` in `packages/torch_ext` have no indication that they are redundant or deprecated. This leaves users uncertain which variant is the canonical API.

- `ScaleEmbedding2` is implementation-identical to `ScaleEmbedding` (same code, same docstring).
- `PositionalEncoding2` wraps `RawPositionalEncoding` in `nn.Sequential` and produces outputs equivalent to `PositionalEncoding`, as asserted by existing tests.

## Changes

- Add `DeprecationWarning` in `ScaleEmbedding2.__init__` pointing users to `ScaleEmbedding`.
- Add `DeprecationWarning` in `PositionalEncoding2.__init__` pointing users to `PositionalEncoding`.
- Clarify `RawPositionalEncoding` docstring as an internal building block.
- Update tests to assert the warnings with `pytest.warns(DeprecationWarning)`.

## Verification

- All 26 existing tests pass.
- `ruff check` and `ruff format` clean.
- `mypy` reports no issues (21 source files).
- `torch.jit.script()` continues to work for both deprecated classes (warning fires at instantiation, not during scripting).
