### PR TITLE
ci: add pip-audit vulnerability scan to python-test workflow

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -13,6 +13,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+
+      - name: Export requirements
+        run: uv export --frozen --no-emit-workspace > /tmp/requirements.txt
+
+      - name: Vulnerability scan (pip-audit)
+        run: uvx pip-audit -r /tmp/requirements.txt
+
   actionlint:
     uses: kitsuyui/gh-actions-workflows/.github/workflows/actionlint.yml@a7071a4635eaece62696cd7132306616ce283c47
   test:


### PR DESCRIPTION
## Summary

Add a `security` job to the existing `python-test.yml` CI workflow to detect known vulnerabilities in locked dependencies using `pip-audit`.

**What changed:**
- New `security` job runs on `ubuntu-latest` (no macOS-specific dependencies needed)
- Uses the same pinned action refs as the existing `test` job
- Exports all locked dependencies via `uv export --frozen --no-emit-workspace`
- Runs `uvx pip-audit -r /tmp/requirements.txt` to scan against CVE/GHSA databases
- CI fails (non-zero exit code) if any vulnerability is found

## Motivation

The repository uses Renovate for dependency version updates, but Renovate only proposes version bumps — it does not actively scan locked packages against vulnerability databases. If a package already in `uv.lock` receives a CVE, it would not be detected by existing CI.

With this change, every PR and push to `main` will scan all locked dependencies. If a known vulnerability is found, the `security` job fails and blocks merging.

## Trade-offs

- `uvx pip-audit` is not version-pinned (resolves at runtime), consistent with other `uvx` tooling patterns
- Scans run on every push, adding ~30s of CI time on a lightweight Ubuntu runner
- The `exclude-newer = "2 days"` quarantine window remains as the supply-chain attack mitigation; this scan targets existing CVEs in locked packages