### PR TITLE
Add coverage threshold to octocov config

### DIFF
--- a/.octocov.yml
+++ b/.octocov.yml
@@ -2,6 +2,7 @@
 coverage:
   paths:
     - coverage.xml
+  acceptable: current >= 90%
 codeToTestRatio:
   code:
     - "packages/*/src/**/*.py"


### PR DESCRIPTION
## Summary

The octocov CI step reports coverage but never fails — there is no
`coverage.acceptable` field in `.octocov.yml`, so any drop in coverage
(even to 0%) passes CI.

This PR adds:

```yaml
coverage:
  acceptable: current >= 90%
```

Current coverage is 99.2%, so the 90% threshold gives headroom for
normal churn while blocking large regressions.

## Test plan

- [ ] CI octocov step passes (current coverage ~99.2% >> 90% threshold)
- [ ] Future PRs that drop coverage below 90% will now fail the
      `Report coverage with octocov` step