### PR TITLE
chore: add lefthook to run CI checks locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,34 @@ uv run poe format
 uv run poe check
 ```
 
+## Development
+
+This repository uses [lefthook](https://lefthook.dev/) to run the same checks as CI
+locally, so problems surface before they reach CI.
+
+```sh
+# Install dependencies
+uv sync
+
+# Install the Git hooks (once; requires lefthook on your PATH)
+lefthook install
+```
+
+Once installed, the hooks run automatically:
+
+- **pre-commit**: `uv run poe check`
+- **pre-push**: `uv run poe check` and `uv run poe test`
+
+You can also run the checks manually:
+
+```sh
+uv run poe check
+uv run poe test
+```
+
+CI still runs the full matrix (see `.github/workflows/`); the hooks only bring that
+feedback earlier on your machine.
+
 # LICENSE
 
 MIT License

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,13 @@
+# Clear Git hook environment variables before running checks so nested or sibling
+# repositories are not affected: https://git-scm.com/docs/githooks
+pre-commit:
+  jobs:
+    - name: check
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; uv run poe check
+
+pre-push:
+  jobs:
+    - name: check
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; uv run poe check
+    - name: test
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; uv run poe test


### PR DESCRIPTION
## Summary

- Adds `lefthook.yml` to run the same checks as CI locally on pre-commit and pre-push
- CI (GitHub Actions) is kept completely unchanged — Actions remain free for public repos
- Developers get faster feedback before changes reach CI

## Changes

- **`lefthook.yml`**: defines two hooks:
  - `pre-commit`: runs `uv run poe check`
  - `pre-push`: runs `uv run poe check` and `uv run poe test`
  - GIT_* environment variables are cleared before each job so nested/sibling repositories are not affected
- **`README.md`**: adds a `## Development` section (inserted before `# LICENSE`) documenting how to install and use lefthook

## Verification

- `uv run poe check` passes locally (all packages: ruff + mypy clean)
- `uv run poe test` passes locally (116 tests across 6 packages)
- Pre-commit hook fired and passed during commit
- Pre-push hook fired and passed (check + test) during push

## Notes

- lefthook must be on your PATH (`lefthook install` is a one-time setup per clone)
- No CI workflows were modified; `.github/workflows/` is untouched
