### PR TITLE
docs: add community health files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Report a reproducible problem in a package, notebook, or workflow
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Summary
+
+<!-- What happened? -->
+
+## Steps to Reproduce
+
+<!-- Include the smallest command, script, notebook cell, or repository state that reproduces the problem. -->
+
+## Expected Behavior
+
+<!-- What did you expect to happen? -->
+
+## Actual Behavior
+
+<!-- What happened instead? Include relevant error output. -->
+
+## Environment
+
+- OS:
+- Python version:
+- Package or notebook:
+- Dependency versions:
+
+## Additional Context
+
+<!-- Do not include secrets or private data. Report suspected vulnerabilities through SECURITY.md instead of a public issue. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,24 @@
+---
+name: Feature request
+about: Propose a new sample, package change, or workflow improvement
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Problem
+
+<!-- What problem would this solve? -->
+
+## Proposed Change
+
+<!-- Describe the sample, package behavior, or workflow change you want. -->
+
+## Alternatives Considered
+
+<!-- List any smaller or simpler approaches you considered. -->
+
+## Validation
+
+<!-- How should this be tested or demonstrated? -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Summary
+
+<!-- Describe the change and the motivation. -->
+
+## Verification
+
+<!-- Check the commands that apply. -->
+
+- [ ] `uv run poe format`
+- [ ] `uv run poe check`
+- [ ] `uv run poe test`
+- [ ] `uv run poe build`
+- [ ] Documentation or README updates were checked
+
+## Impact
+
+<!-- Note affected packages, notebooks, workflows, or public examples. -->
+
+## Notes
+
+<!-- Include follow-up work or known limitations, if any. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,32 @@
+# Code of Conduct
+
+## Our Standards
+
+This project is a small public workspace for machine learning examples. Keep
+discussion respectful, specific, and focused on improving the repository.
+
+Examples of expected behavior:
+
+- Use welcoming and inclusive language.
+- Give constructive feedback and explain the technical reason for requested
+  changes.
+- Respect that examples may be experimental while still asking for clear tests
+  and documentation.
+- Keep security-sensitive details out of public issues.
+
+Examples of unacceptable behavior:
+
+- Harassment, insults, or discriminatory language.
+- Publishing another person's private information.
+- Repeated off-topic comments that derail an issue or pull request.
+- Public disclosure of a suspected vulnerability before maintainers have a
+  chance to respond.
+
+## Enforcement
+
+Report conduct concerns through the repository owner's GitHub profile contact
+path or, for security-sensitive concerns, through the private vulnerability
+reporting link in `SECURITY.md`.
+
+Maintainers may edit, hide, or remove comments and may block accounts when
+behavior makes project discussion unsafe or unproductive.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,58 @@
+# Contributing
+
+Thank you for taking the time to improve `ml-playground`.
+
+This repository is a Python workspace for machine learning samples and small
+package experiments. Keep changes focused on one topic and prefer examples that
+remain easy to run in a clean checkout.
+
+## Development Setup
+
+Install dependencies with [uv](https://docs.astral.sh/uv/):
+
+```sh
+uv sync
+```
+
+Packages live under `packages/`. The root Poe tasks run the matching task for
+each package.
+
+## Checks
+
+Run formatting before opening a pull request:
+
+```sh
+uv run poe format
+```
+
+Run lint and type checks:
+
+```sh
+uv run poe check
+```
+
+Run the test suite:
+
+```sh
+uv run poe test
+```
+
+Build all packages when changing packaging metadata, package layout, or release
+inputs:
+
+```sh
+uv run poe build
+```
+
+## Pull Requests
+
+Before opening a pull request, please make sure that:
+
+- the change is focused on one topic;
+- relevant checks pass locally;
+- README or package documentation updates are included when behavior changes;
+- new examples remain covered by tests or runnable notebook checks where
+  practical.
+
+When reporting a failing check, include the command you ran and the relevant
+error output.

--- a/README.md
+++ b/README.md
@@ -18,11 +18,19 @@ The repository tracks Python `# type: ignore` markers with [`gh-counter`](https:
 - GitHub Actions runs tests for each versions of Python. (Currently 3.10 - 3.12)
   - This range is determined by lifecycle of Python versions and libraries.
   - Python support table: https://devguide.python.org/versions/
-  - numpy support table: https://numpy.org/neps/nep-0029-deprecation_policy.html 
+  - numpy support table: https://numpy.org/neps/nep-0029-deprecation_policy.html
 - [Renovate](https://github.com/apps/renovate) continuously updates dependencies.
 - [nbmake](https://github.com/treebeardtech/nbmake) tests Jupyter ipynb files.
 
 By doing so, I will ensure that sample codes always function as samples.
+
+## Project health
+
+- Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request.
+- Report suspected vulnerabilities through [SECURITY.md](SECURITY.md), not a
+  public issue.
+- Follow [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) when participating in issues
+  or pull requests.
 
 # Usage
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please do not open a public GitHub Issue to report a security vulnerability.
+
+Use [GitHub's private vulnerability reporting](https://github.com/kitsuyui/ml-playground/security/advisories/new)
+to submit a report. This keeps the details confidential until a fix is ready.
+
+Include the following in your report:
+
+- a description of the vulnerability and its potential impact;
+- steps to reproduce or a minimal proof of concept;
+- affected package, Python version, operating system, and dependency versions;
+- whether the issue affects sample code, package code, notebooks, or CI.
+
+You will receive a response as soon as possible. If the vulnerability is
+confirmed, a fix will be prepared and a public advisory will be published after
+the fix is released.


### PR DESCRIPTION
## Summary
- Add contribution and vulnerability reporting guidance for the workspace.
- Add issue and pull request templates for focused reports and reviews.
- Link the new project health files from the README.

## Changed files
- `CONTRIBUTING.md`
- `SECURITY.md`
- `CODE_OF_CONDUCT.md`
- `README.md`
- `.github/ISSUE_TEMPLATE/bug_report.md`
- `.github/ISSUE_TEMPLATE/feature_request.md`
- `.github/pull_request_template.md`

## Verification
- `git diff --check`
- `typos README.md CONTRIBUTING.md SECURITY.md CODE_OF_CONDUCT.md .github/ISSUE_TEMPLATE/bug_report.md .github/ISSUE_TEMPLATE/feature_request.md .github/pull_request_template.md`
- `actionlint .github/workflows/*.yml`
- `./bin/check-generated-artifacts`
- `uv run poe check`
- `uv run poe test`
- `uv run poe coverage`
