### PR TITLE
docs: explain why packages/dev-shared is excluded from run-each

### DIFF
--- a/bin/run-each
+++ b/bin/run-each
@@ -6,6 +6,8 @@ shift
 
 # Use xargs instead find -exec to pass exit status.
 
+# dev-shared is a dev-tooling meta-package (bundles pytest/ruff/mypy) with no
+# library source code or runnable poe tasks; intentionally excluded from per-package runs.
 # shellcheck disable=SC2016
 find packages \
 -type d \


### PR DESCRIPTION
## Summary

`bin/run-each` hardcoded `-not -path 'packages/dev-shared'` without any explanation, making it
unclear to contributors why `dev-shared` was skipped while all other `packages/*` directories
were iterated.

`packages/dev-shared` is a dev-tooling meta-package that bundles development dependencies
(pytest, ruff, mypy) and has no library source code or runnable `poe` tasks. This PR adds a
comment to make this intent explicit.

## Changes

- `bin/run-each`: added a two-line comment above the exclusion explaining that `dev-shared`
  is a dev-tooling package without library source code or runnable poe tasks.

## Verification

- `shellcheck bin/run-each`: no issues
- No functional change; comment only